### PR TITLE
feat: getRem()のベースフォントサイズを実際のドキュメントスタイルから取得するように変更

### DIFF
--- a/src/libs/get/getRem.test.ts
+++ b/src/libs/get/getRem.test.ts
@@ -1,7 +1,15 @@
 import { getRem } from './getRem'
 
 describe('getRem', () => {
-  it('should convert px to rem correctly', () => {
+  beforeEach(() => {
+    document.documentElement.style.fontSize = '16px'
+  })
+
+  afterEach(() => {
+    document.documentElement.style.fontSize = ''
+  })
+
+  it('should convert px to rem correctly with default 16px root font size', () => {
     expect(getRem(16)).toBe('1rem')
     expect(getRem(32)).toBe('2rem')
     expect(getRem(8)).toBe('0.5rem')
@@ -14,5 +22,19 @@ describe('getRem', () => {
   it('should handle negative values', () => {
     expect(getRem(-16)).toBe('-1rem')
     expect(getRem(-32)).toBe('-2rem')
+  })
+
+  it('should calculate rem based on actual root font size', () => {
+    document.documentElement.style.fontSize = '10px'
+    expect(getRem(10)).toBe('1rem')
+    expect(getRem(20)).toBe('2rem')
+    expect(getRem(5)).toBe('0.5rem')
+  })
+
+  it('should calculate rem correctly with 20px root font size', () => {
+    document.documentElement.style.fontSize = '20px'
+    expect(getRem(20)).toBe('1rem')
+    expect(getRem(40)).toBe('2rem')
+    expect(getRem(10)).toBe('0.5rem')
   })
 })

--- a/src/libs/get/getRem.ts
+++ b/src/libs/get/getRem.ts
@@ -1,10 +1,13 @@
 /**
  * Converts a pixel value to rem units.
+ * Calculates based on the actual root font size of the document.
  *
  * @param px - The pixel value to be converted.
  * @returns The equivalent value in rem units as a string.
  */
 export const getRem = (px: number): string => {
-  const baseFontSize = 16
-  return `${px / baseFontSize}rem`
+  const rootFontSize = parseFloat(
+    getComputedStyle(document.documentElement).fontSize
+  )
+  return `${px / rootFontSize}rem`
 }


### PR DESCRIPTION
## 概要
- `getRem()`関数のベースフォントサイズを固定値(16px)ではなく、`getComputedStyle(document.documentElement).fontSize`を使用して実際のルートフォントサイズから動的に取得するように変更
- 異なるルートフォントサイズでのテストケースを追加

## 変更内容
- `src/libs/get/getRem.ts`: 動的なルートフォントサイズ取得に変更
- `src/libs/get/getRem.test.ts`: テストケースの追加・更新

## テスト計画
- [x] `pnpm lint` 成功
- [x] `pnpm test:run` 成功（全196テスト通過）
- [x] `pnpm build` 成功

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)