### PR TITLE
chore: add release-drafter and documentation updates

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,113 @@
+# Release Drafter Configuration
+# https://github.com/release-drafter/release-drafter
+
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+# Categories for release notes
+categories:
+  - title: '✨ New Features'
+    labels:
+      - 'enhancement'
+      - 'feature'
+      - 'version: Minor'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+      - 'fix'
+  - title: '💥 Breaking Changes'
+    labels:
+      - 'breaking-change'
+      - 'version: Major'
+  - title: '📦 Dependencies'
+    labels:
+      - 'dependencies'
+  - title: '🔧 Maintenance'
+    labels:
+      - 'chore'
+      - 'maintenance'
+      - 'version: Patch'
+  - title: '📝 Documentation'
+    labels:
+      - 'documentation'
+      - 'docs'
+  - title: '🧪 Tests'
+    labels:
+      - 'test'
+      - 'tests'
+  - title: '🎨 Styling'
+    labels:
+      - 'style'
+  - title: '♻️ Refactoring'
+    labels:
+      - 'refactor'
+  - title: '⚡ Performance'
+    labels:
+      - 'performance'
+      - 'perf'
+
+# Exclude certain labels from release notes
+exclude-labels:
+  - 'skip-changelog'
+  - 'no-changelog'
+
+# Version resolver based on labels
+version-resolver:
+  major:
+    labels:
+      - 'version: Major'
+      - 'breaking-change'
+  minor:
+    labels:
+      - 'version: Minor'
+      - 'enhancement'
+      - 'feature'
+  patch:
+    labels:
+      - 'version: Patch'
+      - 'bug'
+      - 'fix'
+      - 'chore'
+      - 'dependencies'
+      - 'documentation'
+  default: patch
+
+# Template for release notes
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  ---
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
+# Autolabeler for PRs based on title/branch
+autolabeler:
+  - label: 'enhancement'
+    title:
+      - '/^feat(\(.+\))?:/i'
+  - label: 'bug'
+    title:
+      - '/^fix(\(.+\))?:/i'
+  - label: 'documentation'
+    title:
+      - '/^docs(\(.+\))?:/i'
+  - label: 'chore'
+    title:
+      - '/^chore(\(.+\))?:/i'
+  - label: 'refactor'
+    title:
+      - '/^refactor(\(.+\))?:/i'
+  - label: 'test'
+    title:
+      - '/^test(\(.+\))?:/i'
+  - label: 'style'
+    title:
+      - '/^style(\(.+\))?:/i'
+  - label: 'performance'
+    title:
+      - '/^perf(\(.+\))?:/i'
+  - label: 'breaking-change'
+    title:
+      - '/^.+!:/i'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,27 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,6 +369,71 @@ mcp__github__create_pull_request({
 
 **チェックボックスのいずれかがチェックされていない場合、PRを作成しない。まず問題を修正する。**
 
+### GitHub リリース作成ガイドライン
+
+**⚠️ 重要: リリースはタグが作成された後に実行する**
+
+#### リリースの作成手順
+
+1. **前回のバージョンからの変更を確認:**
+
+```bash
+git fetch --tags
+git log v0.6.3..v0.7.0 --oneline
+```
+
+2. **`gh release create`を使用してリリースを作成:**
+
+```bash
+gh release create v0.7.0 --title "v0.7.0" --notes "$(cat <<'EOF'
+## ✨ New Features
+
+### 機能名 (#Issue番号)
+機能の説明
+
+**Before (v0.x.x)**
+```ts
+// 変更前のコード例
+```
+
+**After (v0.y.0)**
+```ts
+// 変更後のコード例
+```
+
+## 📦 Dependencies
+
+- 依存関係の更新内容
+
+## 🔧 Maintenance
+
+- メンテナンス関連の変更
+
+---
+
+**Full Changelog**: https://github.com/TsubasaHiga/umaki/compare/v0.6.3...v0.7.0
+EOF
+)"
+```
+
+#### リリースノートのセクション
+
+状況に応じて以下のセクションを使用:
+
+- `## ✨ New Features` - 新機能
+- `## 🐛 Bug Fixes` - バグ修正
+- `## 💥 Breaking Changes` - 破壊的変更
+- `## 📦 Dependencies` - 依存関係の更新
+- `## 🔧 Maintenance` - メンテナンス・設定変更
+- `## 📝 Documentation` - ドキュメント更新
+
+#### リリースノートのベストプラクティス
+
+- 主要な変更には **Before/After** のコード例を含める
+- Issue番号を `(#123)` 形式でリンクする
+- `**Full Changelog**` リンクを末尾に含める
+- ユーザーに影響のある変更を優先的に記載する
+
 ## コミット前チェックリスト
 
 **変更をコミットする前に全項目を完了すること:**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umaki",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A utility that is often used in web production.",
   "author": "TsubasaHiga",
   "homepage": "https://github.com/TsubasaHiga/umaki",


### PR DESCRIPTION
## 概要
- release-drafterの設定を追加
- CLAUDE.mdにGitHubリリース作成ガイドラインを追加

## 変更内容

### release-drafter設定
- `.github/release-drafter.yml` - カテゴリ設定、version-resolver、autolabeler
- `.github/workflows/release-drafter.yml` - ワークフロー定義

### ドキュメント更新
- `CLAUDE.md` - GitHubリリース作成ガイドラインを追加

## 動作
- PRが`main`にマージされると、release-drafterが自動的にリリースドラフトを更新
- 既存の`version-management.yaml`と連携して動作

## テスト計画
- [x] 設定ファイルの構文確認
- [x] ワークフローファイルの構文確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)