### PR TITLE
refactor: use git tag for release-drafter version

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,6 @@
 # Release Drafter Configuration
 # https://github.com/release-drafter/release-drafter
+# Version is determined by the latest git tag (set in workflow)
 
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
@@ -51,27 +52,6 @@ exclude-labels:
   - 'skip-changelog'
   - 'no-changelog'
 
-# Version resolver based on labels
-version-resolver:
-  major:
-    labels:
-      - 'version: Major'
-      - 'breaking-change'
-  minor:
-    labels:
-      - 'version: Minor'
-      - 'enhancement'
-      - 'feature'
-  patch:
-    labels:
-      - 'version: Patch'
-      - 'bug'
-      - 'fix'
-      - 'chore'
-      - 'dependencies'
-      - 'documentation'
-  default: patch
-
 # Template for release notes
 template: |
   ## What's Changed
@@ -81,33 +61,3 @@ template: |
   ---
 
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
-
-# Autolabeler for PRs based on title/branch
-autolabeler:
-  - label: 'enhancement'
-    title:
-      - '/^feat(\(.+\))?:/i'
-  - label: 'bug'
-    title:
-      - '/^fix(\(.+\))?:/i'
-  - label: 'documentation'
-    title:
-      - '/^docs(\(.+\))?:/i'
-  - label: 'chore'
-    title:
-      - '/^chore(\(.+\))?:/i'
-  - label: 'refactor'
-    title:
-      - '/^refactor(\(.+\))?:/i'
-  - label: 'test'
-    title:
-      - '/^test(\(.+\))?:/i'
-  - label: 'style'
-    title:
-      - '/^style(\(.+\))?:/i'
-  - label: 'performance'
-    title:
-      - '/^perf(\(.+\))?:/i'
-  - label: 'breaking-change'
-    title:
-      - '/^.+!:/i'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read
@@ -17,6 +15,25 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get latest tag
+        id: get-tag
+        run: |
+          # Get the latest tag
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          # Remove 'v' prefix for version
+          VERSION=${LATEST_TAG#v}
+          echo "Latest tag: $LATEST_TAG"
+          echo "Version: $VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create release draft
+        uses: release-drafter/release-drafter@v6
+        with:
+          version: ${{ steps.get-tag.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umaki",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "A utility that is often used in web production.",
   "author": "TsubasaHiga",
   "homepage": "https://github.com/TsubasaHiga/umaki",


### PR DESCRIPTION
## 概要
release-drafterのバージョン決定をラベルベースからタグベースに変更

## 変更内容

### ワークフロー変更
- 最新のgitタグからバージョンを取得してrelease-drafterに渡す
- PRトリガーを削除（mainへのpushのみで実行）

### 設定変更
- version-resolverを削除（タグベースに移行したため不要）
- autolabelerを削除（PRトリガーがないため不要）

## メリット
- version-management.yamlが作成したタグと完全に一致
- ラベルの付け方による不一致が発生しない

## テスト計画
- [ ] PRマージ後にrelease-drafterが正しいバージョンでドラフトを作成することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)