### PR TITLE
feat: add tap and tapAsync callback functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+// Callback functions
+export * from '@libs/callback/'
+
 // Configuration
 export * from '@libs/config/'
 

--- a/src/libs/callback/index.ts
+++ b/src/libs/callback/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Callback functions
+ */
+
+export { tap } from './tap'
+export { tapAsync } from './tap-async'

--- a/src/libs/callback/tap-async.test.ts
+++ b/src/libs/callback/tap-async.test.ts
@@ -1,0 +1,120 @@
+import { tapAsync } from './tap-async'
+
+describe('tapAsync', () => {
+  it('should return the resolved value unchanged', async () => {
+    const value = 'hello'
+    const result = await tapAsync(Promise.resolve(value), () => {})
+    expect(result).toBe(value)
+  })
+
+  it('should call the callback with the resolved value', async () => {
+    const value = 42
+    const callback = vi.fn()
+    await tapAsync(Promise.resolve(value), callback)
+    expect(callback).toHaveBeenCalledWith(value)
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('should work with objects', async () => {
+    const value = { name: 'test', count: 1 }
+    const callback = vi.fn()
+    const result = await tapAsync(Promise.resolve(value), callback)
+    expect(result).toEqual(value)
+    expect(callback).toHaveBeenCalledWith(value)
+  })
+
+  it('should work with arrays', async () => {
+    const value = [1, 2, 3]
+    const callback = vi.fn()
+    const result = await tapAsync(Promise.resolve(value), callback)
+    expect(result).toEqual(value)
+    expect(callback).toHaveBeenCalledWith(value)
+  })
+
+  it('should work with null', async () => {
+    const value = null
+    const callback = vi.fn()
+    const result = await tapAsync(Promise.resolve(value), callback)
+    expect(result).toBe(value)
+    expect(callback).toHaveBeenCalledWith(value)
+  })
+
+  it('should work with undefined', async () => {
+    const value = undefined
+    const callback = vi.fn()
+    const result = await tapAsync(Promise.resolve(value), callback)
+    expect(result).toBe(value)
+    expect(callback).toHaveBeenCalledWith(value)
+  })
+
+  it('should ignore the callback return value', async () => {
+    const value = 'original'
+    const result = await tapAsync(Promise.resolve(value), () => 'modified')
+    expect(result).toBe('original')
+  })
+
+  it('should execute callback after promise resolves', async () => {
+    const order: number[] = []
+    order.push(1)
+
+    const promise = new Promise<string>((resolve) => {
+      setTimeout(() => {
+        order.push(2)
+        resolve('value')
+      }, 10)
+    })
+
+    await tapAsync(promise, () => order.push(3))
+    order.push(4)
+
+    expect(order).toEqual([1, 2, 3, 4])
+  })
+
+  it('should work with Promise.all for parallel execution', async () => {
+    const results: string[] = []
+
+    const promise1 = new Promise<string>((resolve) => {
+      setTimeout(() => resolve('first'), 30)
+    })
+    const promise2 = new Promise<string>((resolve) => {
+      setTimeout(() => resolve('second'), 10)
+    })
+    const promise3 = new Promise<string>((resolve) => {
+      setTimeout(() => resolve('third'), 20)
+    })
+
+    const [r1, r2, r3] = await Promise.all([
+      tapAsync(promise1, (v) => results.push(v)),
+      tapAsync(promise2, (v) => results.push(v)),
+      tapAsync(promise3, (v) => results.push(v))
+    ])
+
+    expect(r1).toBe('first')
+    expect(r2).toBe('second')
+    expect(r3).toBe('third')
+    // Callbacks are called in order of resolution, not declaration
+    expect(results).toEqual(['second', 'third', 'first'])
+  })
+
+  it('should propagate errors from the promise', async () => {
+    const error = new Error('test error')
+    const callback = vi.fn()
+
+    await expect(tapAsync(Promise.reject(error), callback)).rejects.toThrow(
+      'test error'
+    )
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('should handle async delay correctly', async () => {
+    const delay = (ms: number) =>
+      new Promise<number>((resolve) => setTimeout(() => resolve(ms), ms))
+
+    const callback = vi.fn()
+    const result = await tapAsync(delay(50), callback)
+
+    expect(result).toBe(50)
+    expect(callback).toHaveBeenCalledWith(50)
+  })
+})

--- a/src/libs/callback/tap-async.ts
+++ b/src/libs/callback/tap-async.ts
@@ -1,0 +1,54 @@
+/**
+ * Awaits a Promise, executes a callback with the resolved value, and returns the original value.
+ * Useful for performing side effects (logging, caching, analytics, etc.) on async values without modifying them.
+ *
+ * @param promise - The Promise to await.
+ * @param callback - A function that receives the resolved value. Its return value is ignored.
+ * @returns A Promise that resolves to the original value.
+ *
+ * @example
+ * ```ts
+ * import { tapAsync } from 'umaki'
+ *
+ * // Logging async results
+ * const data = await tapAsync(fetchData(), (result) => {
+ *   console.log('Fetched:', result)
+ * })
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Caching async results
+ * const getData = () => tapAsync(
+ *   fetchFromServer(),
+ *   (data) => cache.set('data', data)
+ * )
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Parallel execution with individual completion tracking
+ * await Promise.all([
+ *   tapAsync(fetchUserData(), (user) => console.log('user loaded')),
+ *   tapAsync(fetchProductData(), (products) => console.log('products loaded')),
+ *   tapAsync(fetchOrderData(), (orders) => console.log('orders loaded'))
+ * ])
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Event emission on async completion
+ * const loadUser = () => tapAsync(
+ *   fetchUser(),
+ *   (user) => eventEmitter.emit('userLoaded', user)
+ * )
+ * ```
+ */
+export const tapAsync = async <T>(
+  promise: Promise<T>,
+  callback: (value: T) => void
+): Promise<T> => {
+  const value = await promise
+  callback(value)
+  return value
+}

--- a/src/libs/callback/tap.test.ts
+++ b/src/libs/callback/tap.test.ts
@@ -1,0 +1,72 @@
+import { tap } from './tap'
+
+describe('tap', () => {
+  it('should return the original value unchanged', () => {
+    const value = 'hello'
+    const result = tap(value, () => {})
+    expect(result).toBe(value)
+  })
+
+  it('should call the callback with the value', () => {
+    const value = 42
+    const callback = vi.fn()
+    tap(value, callback)
+    expect(callback).toHaveBeenCalledWith(value)
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('should work with objects', () => {
+    const value = { name: 'test', count: 1 }
+    const callback = vi.fn()
+    const result = tap(value, callback)
+    expect(result).toBe(value)
+    expect(callback).toHaveBeenCalledWith(value)
+  })
+
+  it('should work with arrays', () => {
+    const value = [1, 2, 3]
+    const callback = vi.fn()
+    const result = tap(value, callback)
+    expect(result).toBe(value)
+    expect(callback).toHaveBeenCalledWith(value)
+  })
+
+  it('should work with null', () => {
+    const value = null
+    const callback = vi.fn()
+    const result = tap(value, callback)
+    expect(result).toBe(value)
+    expect(callback).toHaveBeenCalledWith(value)
+  })
+
+  it('should work with undefined', () => {
+    const value = undefined
+    const callback = vi.fn()
+    const result = tap(value, callback)
+    expect(result).toBe(value)
+    expect(callback).toHaveBeenCalledWith(value)
+  })
+
+  it('should work with functions (higher-order functions)', () => {
+    const fn = () => 'result'
+    const callback = vi.fn()
+    const result = tap(fn, callback)
+    expect(result).toBe(fn)
+    expect(callback).toHaveBeenCalledWith(fn)
+    expect(result()).toBe('result')
+  })
+
+  it('should ignore the callback return value', () => {
+    const value = 'original'
+    const result = tap(value, () => 'modified')
+    expect(result).toBe('original')
+  })
+
+  it('should execute callback synchronously', () => {
+    const order: number[] = []
+    order.push(1)
+    tap('value', () => order.push(2))
+    order.push(3)
+    expect(order).toEqual([1, 2, 3])
+  })
+})

--- a/src/libs/callback/tap.ts
+++ b/src/libs/callback/tap.ts
@@ -1,0 +1,41 @@
+/**
+ * Type that excludes Promise types.
+ * Used to prevent passing async values to synchronous tap function.
+ */
+type NotPromise<T> = T extends Promise<unknown> ? never : T
+
+/**
+ * Executes a callback with the given value and returns the original value unchanged.
+ * Useful for performing side effects (logging, analytics, etc.) in a pipeline without modifying the value.
+ *
+ * @param value - The value to pass to the callback. Must not be a Promise (use tapAsync for async values).
+ * @param callback - A function that receives the value. Its return value is ignored.
+ * @returns The original value unchanged.
+ *
+ * @example
+ * ```ts
+ * import { tap, removeAllHtmlTags } from 'umaki'
+ *
+ * const input = '<p>Hello <strong>World</strong>!</p>'
+ * const output = tap(removeAllHtmlTags(input), (result) => {
+ *   console.log('Sanitized:', result)
+ * })
+ * // Logs: 'Sanitized: Hello World!'
+ * // output = 'Hello World!'
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Caching example
+ * const data = tap(processData(raw), (result) => {
+ *   cache.set('processed', result)
+ * })
+ * ```
+ */
+export const tap = <T>(
+  value: NotPromise<T>,
+  callback: (value: T) => void
+): T => {
+  callback(value as T)
+  return value as T
+}


### PR DESCRIPTION
## 概要

Issue #25 に対応し、umakiの関数にコールバックを追加できる `tap` / `tapAsync` 関数を実装しました。

### 追加した関数

| 関数 | 用途 | 特徴 |
|------|------|------|
| `tap` | 同期関数用 | Promiseを型で除外 |
| `tapAsync` | 非同期関数用 | Promise専用 |

### 主な機能

- **型安全**: `tap`にPromiseを渡すとTypeScriptエラー
- **既存関数と併用可能**: umakiの全関数で利用可能
- **用途**: ログ出力、キャッシュ、アナリティクス、イベント発火など

### 使用例

```ts
import { tap, tapAsync, removeAllHtmlTags, sleep } from 'umaki'

// 同期
const output = tap(removeAllHtmlTags(input), (v) => console.log('done!', v))

// 非同期
const data = await tapAsync(fetchData(), (v) => cache.set('data', v))

// Promise.all + 個別トラッキング
await Promise.all([
  tapAsync(fetchUser(), (u) => console.log('user loaded')),
  tapAsync(fetchProducts(), (p) => console.log('products loaded'))
])
```

### ドキュメント

- README.md に Callback セクションを追加
- Advanced Usage セクションを新設（実践的な使用例）

## テスト計画

- [x] `pnpm test:run` - 全216テスト通過（新規20テスト含む）
- [x] `pnpm lint` - エラーなし
- [x] `pnpm build` - ビルド成功

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)