### PR TITLE
refactor: improve get category functions (#106)

### DIFF
--- a/src/libs/get/get-event-paths.ts
+++ b/src/libs/get/get-event-paths.ts
@@ -7,7 +7,7 @@ export const getEventPaths = (evt: Event): (Node | Window)[] => {
   let path = evt.composedPath?.() || null
   const target = evt.target as Node
 
-  if (path != null) {
+  if (path !== null) {
     // Safari doesn't include Window, and it should.
     path = path.indexOf(window) < 0 ? path.concat([window]) : path
     return path as (Node | Window)[]

--- a/src/libs/get/get-gcd.ts
+++ b/src/libs/get/get-gcd.ts
@@ -11,8 +11,8 @@ import { toPositiveNumber } from '@libs/to/to-positive-number'
  * @returns The greatest common divisor of the two numbers.
  */
 export const getGcd = (a: number, b: number): number => {
-  const positiveA = toPositiveNumber(Math.abs(a))
-  const positiveB = toPositiveNumber(Math.abs(b))
+  const positiveA = toPositiveNumber(a)
+  const positiveB = toPositiveNumber(b)
 
   if (positiveB === 0) return positiveA
   return getGcd(positiveB, positiveA % positiveB)

--- a/src/libs/get/get-query-params.ts
+++ b/src/libs/get/get-query-params.ts
@@ -39,7 +39,5 @@ export const getQueryParams = (
   const params = queryParsed[query]
   if (params === null || params === undefined) return null
 
-  // console.log({ queryParsed, params })
-
   return params
 }

--- a/src/libs/get/get-session-storage.ts
+++ b/src/libs/get/get-session-storage.ts
@@ -6,7 +6,7 @@ import store from 'store2'
  * @param key - The key of the session storage item to retrieve.
  * @returns The value associated with the key, or null if the key does not exist.
  */
-export const getSessionStorage = (key: string): unknown | null => {
+export const getSessionStorage = (key: string): unknown => {
   // valueを取得
   const value = store.session.get(key)
 


### PR DESCRIPTION
## 概要

getカテゴリの関数をリファクタリングしました。

### 変更内容

#### `get-gcd.ts`
- `toPositiveNumber(Math.abs(a))` の冗長な呼び出しを `toPositiveNumber(a)` に簡潔化（`toPositiveNumber`内部で既に`Math.abs`を使用）

#### `get-query-params.ts`
- コメントアウトされた `console.log` を削除

#### `get-session-storage.ts`
- 戻り値の型を `unknown | null` から `unknown` に簡潔化（`unknown`は`null`を含むため冗長）

#### `get-event-paths.ts`
- `!= null` を `!== null` に変更（厳密等価演算子に統一）

## 関連Issue

Closes #106

## テスト計画

- [x] `pnpm test:run` 成功 (244 tests)
- [x] `pnpm lint` 成功
- [x] `pnpm build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)