### PR TITLE
refactor: improve wait category functions (#107)

### DIFF
--- a/src/libs/wait/sleep.ts
+++ b/src/libs/wait/sleep.ts
@@ -5,5 +5,5 @@
  * @returns A promise that resolves after the specified time.
  */
 export const sleep = (time: number): Promise<void> => {
-  return new Promise((resolve) => setTimeout(resolve, time * 1000, 'foo'))
+  return new Promise((resolve) => setTimeout(resolve, time * 1000))
 }

--- a/src/libs/wait/wait-for-all-media-loaded.ts
+++ b/src/libs/wait/wait-for-all-media-loaded.ts
@@ -7,9 +7,9 @@
 export const waitForAllMediaLoaded = async (
   firstViewOnly = false
 ): Promise<boolean> => {
-  if (!document.images) return Promise.resolve(true)
+  if (!document.images) return true
 
-  if (document.images.length === 0) return Promise.resolve(true)
+  if (document.images.length === 0) return true
 
   const images = Array.from(document.images).filter(
     (img) => img.getAttribute('loading') !== 'lazy'
@@ -32,7 +32,7 @@ export const waitForAllMediaLoaded = async (
     })
   }
 
-  if (mediaElements.length === 0) return Promise.resolve(true)
+  if (mediaElements.length === 0) return true
 
   await Promise.all(
     mediaElements.map((media) => {


### PR DESCRIPTION
## 概要

waitカテゴリの関数をリファクタリングしました。

### 変更内容

#### `sleep.ts`
- `setTimeout` の不要な第3引数 `'foo'` を削除

#### `wait-for-all-media-loaded.ts`
- `Promise.resolve(true)` を単純な `return true` に変更
  - async関数では戻り値は自動的にPromiseでラップされるため、`Promise.resolve()` は不要

## 関連Issue

Closes #107

## テスト計画

- [x] `pnpm test:run` 成功 (244 tests)
- [x] `pnpm lint` 成功
- [x] `pnpm build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)