### PR TITLE
refactor: convert htmlSanitize to const arrow function (#110)

### DIFF
--- a/src/libs/security/html-sanitize.ts
+++ b/src/libs/security/html-sanitize.ts
@@ -7,9 +7,9 @@ import DOMPurify from 'isomorphic-dompurify'
  * @param config - Optional configuration for DOMPurify.
  * @returns The sanitized HTML string.
  */
-export function htmlSanitize(
+export const htmlSanitize = (
   html: string,
   config: Parameters<typeof DOMPurify.sanitize>[1] = {}
-): string {
+): string => {
   return DOMPurify.sanitize(html, config)
 }


### PR DESCRIPTION
## 概要

securityカテゴリの関数をリファクタリングしました。

### 変更内容

#### `html-sanitize.ts`
- `function htmlSanitize()` を `const htmlSanitize = () =>` に変更
- コードスタイルを他の関数と統一（const + arrow function）

## 関連Issue

Closes #110

## テスト計画

- [x] `pnpm test:run` 成功 (244 tests)
- [x] `pnpm lint` 成功
- [x] `pnpm build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)