### PR TITLE
refactor: replace non-null assertion with nullish coalescing in isTouchSupport (#111)

### DIFF
--- a/src/libs/is/is-touch-support.ts
+++ b/src/libs/is/is-touch-support.ts
@@ -23,8 +23,8 @@ export const isTouchSupport = (): boolean => {
     // We need to use type assertion since msMaxTouchPoints is not in standard Navigator type
     typeof (navigator as Navigator & { msMaxTouchPoints?: number })
       .msMaxTouchPoints === 'number' &&
-    (navigator as Navigator & { msMaxTouchPoints?: number }).msMaxTouchPoints! >
-      0
+    ((navigator as Navigator & { msMaxTouchPoints?: number })
+      .msMaxTouchPoints ?? 0) > 0
 
   return hasTouchStart || hasTouchPoints || hasMsTouchPoints
 }


### PR DESCRIPTION
## 概要

isカテゴリのリファクタリングを実施しました。

### 変更内容

- `is-touch-support.ts`: 非null断言(`!`)をnullish coalescing(`??`)に置き換え

**Before**
```typescript
((navigator as Navigator & { msMaxTouchPoints?: number })
  .msMaxTouchPoints!) > 0
```

**After**
```typescript
((navigator as Navigator & { msMaxTouchPoints?: number }).msMaxTouchPoints ??
  0) > 0
```

## テスト計画
- [x] `pnpm test:run` 成功（244 tests passed）
- [x] `pnpm lint` 成功
- [x] `pnpm build` 成功

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)