### PR TITLE
feat: add copyToClipboard utility function

### DIFF
--- a/src/libs/control/copy-to-clipboard.test.ts
+++ b/src/libs/control/copy-to-clipboard.test.ts
@@ -1,0 +1,91 @@
+import { copyToClipboard } from './copy-to-clipboard'
+
+describe('copyToClipboard', () => {
+  const originalNavigator = global.navigator
+
+  afterEach(() => {
+    Object.defineProperty(global, 'navigator', {
+      value: originalNavigator,
+      writable: true,
+      configurable: true
+    })
+    vi.restoreAllMocks()
+  })
+
+  it('should return true when clipboard write succeeds', async () => {
+    const mockWriteText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(global, 'navigator', {
+      value: {
+        clipboard: {
+          writeText: mockWriteText
+        }
+      },
+      writable: true,
+      configurable: true
+    })
+
+    const result = await copyToClipboard('test text')
+
+    expect(result).toBe(true)
+    expect(mockWriteText).toHaveBeenCalledWith('test text')
+  })
+
+  it('should return false when clipboard write fails', async () => {
+    const mockWriteText = vi.fn().mockRejectedValue(new Error('Failed'))
+    Object.defineProperty(global, 'navigator', {
+      value: {
+        clipboard: {
+          writeText: mockWriteText
+        }
+      },
+      writable: true,
+      configurable: true
+    })
+
+    const result = await copyToClipboard('test text')
+
+    expect(result).toBe(false)
+  })
+
+  it('should return false when navigator is undefined', async () => {
+    Object.defineProperty(global, 'navigator', {
+      value: undefined,
+      writable: true,
+      configurable: true
+    })
+
+    const result = await copyToClipboard('test text')
+
+    expect(result).toBe(false)
+  })
+
+  it('should return false when clipboard API is not available', async () => {
+    Object.defineProperty(global, 'navigator', {
+      value: {},
+      writable: true,
+      configurable: true
+    })
+
+    const result = await copyToClipboard('test text')
+
+    expect(result).toBe(false)
+  })
+
+  it('should handle empty string', async () => {
+    const mockWriteText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(global, 'navigator', {
+      value: {
+        clipboard: {
+          writeText: mockWriteText
+        }
+      },
+      writable: true,
+      configurable: true
+    })
+
+    const result = await copyToClipboard('')
+
+    expect(result).toBe(true)
+    expect(mockWriteText).toHaveBeenCalledWith('')
+  })
+})

--- a/src/libs/control/copy-to-clipboard.ts
+++ b/src/libs/control/copy-to-clipboard.ts
@@ -1,0 +1,39 @@
+/**
+ * Copies the specified text to the clipboard.
+ *
+ * Uses the modern Clipboard API (navigator.clipboard.writeText).
+ * Returns a promise that resolves to true on success, false on failure.
+ *
+ * @param text - The text to copy to the clipboard.
+ * @returns A promise that resolves to `true` if the copy was successful, `false` otherwise.
+ *
+ * @example
+ * ```ts
+ * // Basic usage
+ * const success = await copyToClipboard('Hello, World!')
+ * if (success) {
+ *   console.log('Copied to clipboard!')
+ * } else {
+ *   console.log('Failed to copy')
+ * }
+ *
+ * // With async/await error handling
+ * try {
+ *   await copyToClipboard('Some text')
+ * } catch (error) {
+ *   console.error('Copy failed:', error)
+ * }
+ * ```
+ */
+export const copyToClipboard = async (text: string): Promise<boolean> => {
+  if (typeof navigator === 'undefined' || !navigator.clipboard) {
+    return false
+  }
+
+  try {
+    await navigator.clipboard.writeText(text)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/libs/control/index.ts
+++ b/src/libs/control/index.ts
@@ -3,6 +3,7 @@
  */
 
 export * from './bg-scroll-stop'
+export * from './copy-to-clipboard'
 export * from './pd'
 export * from './scroll-to-hash'
 export * from './video-play-control'


### PR DESCRIPTION
## 概要
- テキストをクリップボードにコピーする`copyToClipboard`関数を追加

## 変更内容
- `src/libs/control/copy-to-clipboard.ts` - 実装
- `src/libs/control/copy-to-clipboard.test.ts` - テスト
- `src/libs/control/index.ts` - エクスポート追加

## 機能
- `navigator.clipboard.writeText`を使用したモダンなClipboard API対応
- 成功時`true`、失敗時`false`を返すPromise
- SSR環境でのundefined対応

Closes #128

## テスト計画
- [x] `pnpm test:run` 成功
- [x] `pnpm lint` 成功
- [x] `pnpm build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)