### PR TITLE
fix: バグ修正10件（#141-#150）- ライブラリ監査で発見された問題の対応

### DIFF
--- a/src/libs/config/_internal.ts
+++ b/src/libs/config/_internal.ts
@@ -1,0 +1,10 @@
+import { defaultConfig } from './default-config'
+import type { UmakiConfig } from './types'
+
+/**
+ * Internal module for shared configuration state.
+ * This module should NOT be exported publicly.
+ */
+
+// The current configuration, starting with the default values
+export const currentConfig: UmakiConfig = { ...defaultConfig }

--- a/src/libs/config/get-config.ts
+++ b/src/libs/config/get-config.ts
@@ -1,8 +1,5 @@
-import { defaultConfig } from './default-config'
+import { currentConfig } from './_internal'
 import type { UmakiConfig } from './types'
-
-// The current configuration, starting with the default values
-const currentConfig: UmakiConfig = { ...defaultConfig }
 
 /**
  * Get the current configuration
@@ -22,6 +19,3 @@ export const getConfigValue = <K extends keyof UmakiConfig>(
 ): UmakiConfig[K] => {
   return currentConfig[key]
 }
-
-// Export for internal use by setConfig
-export { currentConfig }

--- a/src/libs/config/set-config.ts
+++ b/src/libs/config/set-config.ts
@@ -1,4 +1,4 @@
-import { currentConfig } from './get-config'
+import { currentConfig } from './_internal'
 import type { UmakiConfig } from './types'
 
 /**

--- a/src/libs/eventControl/debounce.test.ts
+++ b/src/libs/eventControl/debounce.test.ts
@@ -49,4 +49,32 @@ describe('debounce', () => {
     vi.advanceTimersByTime(200)
     expect(fn).toHaveBeenCalledTimes(1)
   })
+
+  it('should throw error for zero delay', () => {
+    const fn = vi.fn()
+    expect(() => debounce(fn, 0)).toThrow(
+      'delay must be a positive finite number'
+    )
+  })
+
+  it('should throw error for negative delay', () => {
+    const fn = vi.fn()
+    expect(() => debounce(fn, -100)).toThrow(
+      'delay must be a positive finite number'
+    )
+  })
+
+  it('should throw error for NaN delay', () => {
+    const fn = vi.fn()
+    expect(() => debounce(fn, NaN)).toThrow(
+      'delay must be a positive finite number'
+    )
+  })
+
+  it('should throw error for Infinity delay', () => {
+    const fn = vi.fn()
+    expect(() => debounce(fn, Infinity)).toThrow(
+      'delay must be a positive finite number'
+    )
+  })
 })

--- a/src/libs/eventControl/debounce.ts
+++ b/src/libs/eventControl/debounce.ts
@@ -5,13 +5,18 @@ type DebounceProcedure = (...args: unknown[]) => void
  *
  * @template F - The type of the function to debounce.
  * @param {F} fn - The function to debounce.
- * @param {number} delay - The number of milliseconds to delay.
+ * @param {number} delay - The number of milliseconds to delay. Must be a positive number.
  * @returns {(...args: Parameters<F>) => void} - A debounced version of the provided function.
+ * @throws {Error} If delay is not a positive number.
  */
 export const debounce = <F extends DebounceProcedure>(
   fn: F,
   delay: number
 ): ((...args: Parameters<F>) => void) => {
+  if (delay <= 0 || !Number.isFinite(delay)) {
+    throw new Error('delay must be a positive finite number')
+  }
+
   let timeoutId: ReturnType<typeof setTimeout> | null = null
 
   return (...args: Parameters<F>) => {

--- a/src/libs/eventControl/throttle.test.ts
+++ b/src/libs/eventControl/throttle.test.ts
@@ -40,4 +40,32 @@ describe('throttle', () => {
     throttledFn(1, 2, 3)
     expect(fn).toHaveBeenCalledWith(1, 2, 3)
   })
+
+  it('should throw error for zero wait', () => {
+    const fn = vi.fn()
+    expect(() => throttle(fn, 0)).toThrow(
+      'wait must be a positive finite number'
+    )
+  })
+
+  it('should throw error for negative wait', () => {
+    const fn = vi.fn()
+    expect(() => throttle(fn, -100)).toThrow(
+      'wait must be a positive finite number'
+    )
+  })
+
+  it('should throw error for NaN wait', () => {
+    const fn = vi.fn()
+    expect(() => throttle(fn, NaN)).toThrow(
+      'wait must be a positive finite number'
+    )
+  })
+
+  it('should throw error for Infinity wait', () => {
+    const fn = vi.fn()
+    expect(() => throttle(fn, Infinity)).toThrow(
+      'wait must be a positive finite number'
+    )
+  })
 })

--- a/src/libs/eventControl/throttle.ts
+++ b/src/libs/eventControl/throttle.ts
@@ -6,13 +6,18 @@ type ThrottleFunction = (...args: unknown[]) => void
  *
  * @template F - The type of the function to be throttled.
  * @param fn - The function to throttle.
- * @param wait - The number of milliseconds to wait before allowing the next execution.
+ * @param wait - The number of milliseconds to wait before allowing the next execution. Must be a positive number.
  * @returns A throttled version of the provided function.
+ * @throws {Error} If wait is not a positive number.
  */
 export const throttle = <F extends ThrottleFunction>(
   fn: F,
   wait: number
 ): ((...args: Parameters<F>) => void) => {
+  if (wait <= 0 || !Number.isFinite(wait)) {
+    throw new Error('wait must be a positive finite number')
+  }
+
   let lastCallTime = 0
 
   // Return a throttled function that only executes the original function at most once in the specified wait period.

--- a/src/libs/get/get-aspect-ratio.test.ts
+++ b/src/libs/get/get-aspect-ratio.test.ts
@@ -25,4 +25,37 @@ describe('getAspectRatio', () => {
     const result = getAspectRatio(1, 1)
     expect(result).toEqual({ w: 1, h: 1 })
   })
+
+  it('should throw error for zero width', () => {
+    expect(() => getAspectRatio(0, 100)).toThrow(
+      'Width and height must be positive finite numbers'
+    )
+  })
+
+  it('should throw error for zero height', () => {
+    expect(() => getAspectRatio(100, 0)).toThrow(
+      'Width and height must be positive finite numbers'
+    )
+  })
+
+  it('should throw error for negative values', () => {
+    expect(() => getAspectRatio(-16, 9)).toThrow(
+      'Width and height must be positive finite numbers'
+    )
+    expect(() => getAspectRatio(16, -9)).toThrow(
+      'Width and height must be positive finite numbers'
+    )
+  })
+
+  it('should throw error for NaN', () => {
+    expect(() => getAspectRatio(NaN, 100)).toThrow(
+      'Width and height must be positive finite numbers'
+    )
+  })
+
+  it('should throw error for Infinity', () => {
+    expect(() => getAspectRatio(Infinity, 100)).toThrow(
+      'Width and height must be positive finite numbers'
+    )
+  })
 })

--- a/src/libs/get/get-aspect-ratio.ts
+++ b/src/libs/get/get-aspect-ratio.ts
@@ -3,14 +3,18 @@ import { getGcd } from './get-gcd'
 /**
  * Returns the aspect ratio of the given width and height.
  *
- * @param w - The width value.
- * @param h - The height value.
+ * @param w - The width value. Must be a positive number.
+ * @param h - The height value. Must be a positive number.
  * @returns An object containing the width and height of the aspect ratio.
+ * @throws {Error} If width or height is not a positive number.
  */
 export const getAspectRatio = (
   w: number,
   h: number
 ): { w: number; h: number } => {
+  if (w <= 0 || h <= 0 || !Number.isFinite(w) || !Number.isFinite(h)) {
+    throw new Error('Width and height must be positive finite numbers')
+  }
   const gcd = getGcd(w, h)
   return { w: w / gcd, h: h / gcd }
 }

--- a/src/libs/get/get-orientation.test.ts
+++ b/src/libs/get/get-orientation.test.ts
@@ -32,4 +32,14 @@ describe('getOrientation', () => {
 
     expect(getOrientation()).toBe('portrait')
   })
+
+  it('should return "portrait" in SSR environment (window undefined)', () => {
+    const originalWindow = global.window
+    // @ts-expect-error - Simulating SSR environment
+    delete global.window
+
+    expect(getOrientation()).toBe('portrait')
+
+    global.window = originalWindow
+  })
 })

--- a/src/libs/get/get-orientation.ts
+++ b/src/libs/get/get-orientation.ts
@@ -2,8 +2,12 @@
  * Retrieves the current orientation of the device.
  *
  * @returns {'landscape' | 'portrait'} The current orientation, either 'landscape' or 'portrait'.
+ * Returns 'portrait' as default in SSR environments where window is undefined.
  */
 export const getOrientation = (): 'landscape' | 'portrait' => {
+  if (typeof window === 'undefined') {
+    return 'portrait'
+  }
   const isLandscape = window.matchMedia('(orientation: landscape)').matches
   return isLandscape ? 'landscape' : 'portrait'
 }

--- a/src/libs/get/get-scrollbar-width.test.ts
+++ b/src/libs/get/get-scrollbar-width.test.ts
@@ -1,15 +1,60 @@
 import { getScrollbarWidth } from './get-scrollbar-width'
 
 describe('getScrollbarWidth', () => {
-  it('should return the correct scrollbar width', () => {
-    // Set up the document body with a specific width
-    window.innerWidth = 1024
-    document.body.style.width = '100px'
+  const originalInnerWidth = window.innerWidth
 
-    // Calculate the expected scrollbar width
-    const expectedScrollbarWidth = window.innerWidth - document.body.clientWidth
+  beforeEach(() => {
+    // Reset to original value before each test
+    Object.defineProperty(window, 'innerWidth', {
+      value: 1024,
+      writable: true,
+      configurable: true
+    })
+  })
 
-    // Call the function and check the result
-    expect(getScrollbarWidth()).toBe(expectedScrollbarWidth)
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', {
+      value: originalInnerWidth,
+      writable: true,
+      configurable: true
+    })
+  })
+
+  it('should return the correct scrollbar width using documentElement', () => {
+    Object.defineProperty(window, 'innerWidth', {
+      value: 1024,
+      writable: true,
+      configurable: true
+    })
+
+    // Mock documentElement.clientWidth to simulate scrollbar
+    const originalClientWidth = document.documentElement.clientWidth
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      value: 1009,
+      configurable: true
+    })
+
+    expect(getScrollbarWidth()).toBe(15)
+
+    // Restore
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      value: originalClientWidth,
+      configurable: true
+    })
+  })
+
+  it('should return 0 when no scrollbar is present', () => {
+    Object.defineProperty(window, 'innerWidth', {
+      value: 1024,
+      writable: true,
+      configurable: true
+    })
+
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      value: 1024,
+      configurable: true
+    })
+
+    expect(getScrollbarWidth()).toBe(0)
   })
 })

--- a/src/libs/get/get-scrollbar-width.ts
+++ b/src/libs/get/get-scrollbar-width.ts
@@ -1,7 +1,10 @@
 /**
  * Retrieves the width of the scrollbar.
  *
+ * Uses document.documentElement.clientWidth instead of document.body.clientWidth
+ * to ensure accurate measurement regardless of body element styling (e.g., max-width, margin).
+ *
  * @returns {number} The width of the scrollbar in pixels.
  */
 export const getScrollbarWidth = (): number =>
-  window.innerWidth - document.body.clientWidth
+  window.innerWidth - document.documentElement.clientWidth

--- a/src/libs/get/get-ua-data.test.ts
+++ b/src/libs/get/get-ua-data.test.ts
@@ -54,4 +54,28 @@ describe('getUaData', () => {
       touchSupport: false
     })
   })
+
+  it('should replace multiple spaces with hyphens', () => {
+    const mockResult = {
+      browser: { name: 'Mobile Safari UI', version: '15.0' },
+      engine: { name: 'WebKit Core' },
+      os: { name: 'Mac OS X' },
+      device: { type: 'mobile device' }
+    }
+    // biome-ignore lint/complexity/useArrowFunction: Vitest requires function/class for constructor mocks
+    ;(UAParser as unknown as Mock).mockImplementation(function () {
+      return { getResult: () => mockResult }
+    })
+
+    const uaData = getUaData()
+
+    expect(uaData).toEqual({
+      browserName: 'mobile-safari-ui',
+      browserVersion: '15.0',
+      browserEngine: 'webkit-core',
+      osName: 'mac-os-x',
+      type: 'mobile-device',
+      touchSupport: false
+    })
+  })
 })

--- a/src/libs/get/get-ua-data.ts
+++ b/src/libs/get/get-ua-data.ts
@@ -36,15 +36,17 @@ export const getUaData = (): UaType => {
   const type = result.device.type
 
   const uaString = {
-    browserName: browserName ? browserName.toLowerCase().replace(' ', '-') : '',
+    browserName: browserName
+      ? browserName.toLowerCase().replace(/ /g, '-')
+      : '',
     browserVersion: browserVersion ? browserVersion : '',
     browserEngine: browserEngine
-      ? browserEngine.toLowerCase().replace(' ', '-')
+      ? browserEngine.toLowerCase().replace(/ /g, '-')
       : '',
-    osName: osName ? osName.toLowerCase().replace(' ', '-') : '',
+    osName: osName ? osName.toLowerCase().replace(/ /g, '-') : '',
     type:
       typeof type !== 'undefined'
-        ? type.toLowerCase().replace(' ', '-')
+        ? type.toLowerCase().replace(/ /g, '-')
         : 'laptop',
     touchSupport: isTouchSupport()
   }

--- a/src/libs/is/is-after-date-time.test.ts
+++ b/src/libs/is/is-after-date-time.test.ts
@@ -52,11 +52,17 @@ describe('isAfterDateTime', () => {
     vi.stubGlobal('dayjs', originalDayjs)
   })
 
-  it('should handle invalid date strings', () => {
+  it('should throw error for invalid date strings', () => {
     const now = dayjs('2023-01-01T12:00:00Z')
 
-    // Invalid dates in dayjs are treated as "Invalid Date"
-    // Check implementation-specific behavior
-    expect(isAfterDateTime('not a date', now)).toBe(false)
+    expect(() => isAfterDateTime('not a date', now)).toThrow(
+      'dateA is not a valid date'
+    )
+  })
+
+  it('should throw error for empty string', () => {
+    const now = dayjs('2023-01-01T12:00:00Z')
+
+    expect(() => isAfterDateTime('', now)).toThrow('dateA is not a valid date')
   })
 })

--- a/src/libs/is/is-after-date-time.ts
+++ b/src/libs/is/is-after-date-time.ts
@@ -7,7 +7,11 @@ import dayjs from 'dayjs'
  * @param dateA - A date/time string to compare, parsed with dayjs.
  * @param now - Optional reference time as a Dayjs object; defaults to current time.
  * @returns `true` if `now` is strictly after the parsed `dateA` at millisecond precision; otherwise `false`.
+ * @throws Will throw an error if dateA is not a valid date.
  */
 export const isAfterDateTime = (dateA: string, now = dayjs()): boolean => {
+  if (!dayjs(dateA).isValid()) {
+    throw new Error('dateA is not a valid date')
+  }
   return now.isAfter(dayjs(dateA), 'millisecond')
 }

--- a/src/libs/is/is-in-viewport.test.ts
+++ b/src/libs/is/is-in-viewport.test.ts
@@ -225,4 +225,60 @@ describe('isInViewport', () => {
       expect(isInViewport(element, { threshold: 0.5 })).toBe(false)
     })
   })
+
+  describe('rootMargin percentage calculation', () => {
+    it('should use innerHeight for vertical percentage and innerWidth for horizontal percentage', () => {
+      // window.innerHeight = 768, window.innerWidth = 1024 (set in beforeEach)
+      // rootMargin: "10% 20%" means:
+      // - top/bottom: 768 * 0.1 = 76.8px
+      // - left/right: 1024 * 0.2 = 204.8px
+
+      // Element is 100px above viewport
+      vi.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+        top: -100,
+        left: 100,
+        bottom: -50,
+        right: 200,
+        width: 100,
+        height: 50,
+        x: 100,
+        y: -100,
+        toJSON: () => {}
+      })
+
+      // Without margin: not visible (top: -100, bottom: -50, viewport top: 0)
+      expect(isInViewport(element)).toBe(false)
+
+      // With 10% vertical margin (76.8px), viewport top becomes -76.8
+      // Element bottom (-50) > viewport top (-76.8), so visible
+      expect(isInViewport(element, { rootMargin: '10%' })).toBe(true)
+    })
+
+    it('should use innerWidth for horizontal percentage in two-value syntax', () => {
+      // window.innerWidth = 1024
+      // rootMargin: "0px 10%" means:
+      // - top/bottom: 0px
+      // - left/right: 1024 * 0.1 = 102.4px
+
+      // Element is 80px to the left of viewport
+      vi.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+        top: 100,
+        left: -80,
+        bottom: 200,
+        right: -30,
+        width: 50,
+        height: 100,
+        x: -80,
+        y: 100,
+        toJSON: () => {}
+      })
+
+      // Without margin: not visible (right: -30 < viewport left: 0)
+      expect(isInViewport(element)).toBe(false)
+
+      // With 10% horizontal margin (102.4px), viewport left becomes -102.4
+      // Element right (-30) > viewport left (-102.4), so visible
+      expect(isInViewport(element, { rootMargin: '0px 10%' })).toBe(true)
+    })
+  })
 })

--- a/src/libs/is/is-in-viewport.ts
+++ b/src/libs/is/is-in-viewport.ts
@@ -22,10 +22,14 @@ interface Margins {
 
 /**
  * Parses a CSS-like margin string into margin values.
+ * For percentage values:
+ * - top/bottom use window.innerHeight as the base
+ * - left/right use window.innerWidth as the base
  */
 const parseRootMargin = (rootMargin: string): Margins => {
   const parts = rootMargin.trim().split(/\s+/)
-  const parseValue = (value: string): number => {
+
+  const parseVerticalValue = (value: string): number => {
     if (value.endsWith('%')) {
       const percent = Number.parseFloat(value) / 100
       return window.innerHeight * percent
@@ -33,13 +37,28 @@ const parseRootMargin = (rootMargin: string): Margins => {
     return Number.parseFloat(value) || 0
   }
 
+  const parseHorizontalValue = (value: string): number => {
+    if (value.endsWith('%')) {
+      const percent = Number.parseFloat(value) / 100
+      return window.innerWidth * percent
+    }
+    return Number.parseFloat(value) || 0
+  }
+
   if (parts.length === 1) {
-    const value = parseValue(parts[0])
-    return { top: value, right: value, bottom: value, left: value }
+    // Same value for all sides - use vertical for top/bottom, horizontal for left/right
+    const verticalValue = parseVerticalValue(parts[0])
+    const horizontalValue = parseHorizontalValue(parts[0])
+    return {
+      top: verticalValue,
+      right: horizontalValue,
+      bottom: verticalValue,
+      left: horizontalValue
+    }
   }
   if (parts.length === 2) {
-    const vertical = parseValue(parts[0])
-    const horizontal = parseValue(parts[1])
+    const vertical = parseVerticalValue(parts[0])
+    const horizontal = parseHorizontalValue(parts[1])
     return {
       top: vertical,
       right: horizontal,
@@ -49,17 +68,17 @@ const parseRootMargin = (rootMargin: string): Margins => {
   }
   if (parts.length === 3) {
     return {
-      top: parseValue(parts[0]),
-      right: parseValue(parts[1]),
-      bottom: parseValue(parts[2]),
-      left: parseValue(parts[1])
+      top: parseVerticalValue(parts[0]),
+      right: parseHorizontalValue(parts[1]),
+      bottom: parseVerticalValue(parts[2]),
+      left: parseHorizontalValue(parts[1])
     }
   }
   return {
-    top: parseValue(parts[0]),
-    right: parseValue(parts[1]),
-    bottom: parseValue(parts[2]),
-    left: parseValue(parts[3])
+    top: parseVerticalValue(parts[0]),
+    right: parseHorizontalValue(parts[1]),
+    bottom: parseVerticalValue(parts[2]),
+    left: parseHorizontalValue(parts[3])
   }
 }
 

--- a/src/libs/is/is-ipad.test.ts
+++ b/src/libs/is/is-ipad.test.ts
@@ -51,4 +51,24 @@ describe('isIpad', () => {
 
     expect(isIpad('portrait')).toBe(false)
   })
+
+  it('should return false in SSR environment (window undefined)', () => {
+    const originalWindow = global.window
+    // @ts-expect-error - Simulating SSR environment
+    delete global.window
+
+    expect(isIpad()).toBe(false)
+
+    global.window = originalWindow
+  })
+
+  it('should return false in SSR environment (navigator undefined)', () => {
+    const originalNavigator = global.navigator
+    // @ts-expect-error - Simulating SSR environment
+    delete global.navigator
+
+    expect(isIpad()).toBe(false)
+
+    global.navigator = originalNavigator
+  })
 })

--- a/src/libs/is/is-ipad.ts
+++ b/src/libs/is/is-ipad.ts
@@ -8,8 +8,14 @@ type Orientation = 'portrait' | 'landscape'
  *
  * @param orientation - The desired screen orientation ('portrait' or 'landscape'). Defaults to 'portrait'.
  * @returns `true` if the device is an iPad with the specified orientation, otherwise `false`.
+ * Returns `false` in SSR environments where window/navigator is undefined.
  */
 export const isIpad = (orientation: Orientation = 'portrait'): boolean => {
+  // SSR guard: return false if window or navigator is not available
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+    return false
+  }
+
   const clientData = getUaData()
 
   if (!clientData.touchSupport) return false

--- a/src/libs/security/html-sanitize.test.ts
+++ b/src/libs/security/html-sanitize.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { htmlSanitize } from './html-sanitize'
+import { htmlSanitize, sanitizeHtml } from './html-sanitize'
 
 describe('htmlSanitize', () => {
   it('should sanitize HTML string', () => {
@@ -27,5 +27,17 @@ describe('htmlSanitize', () => {
     const html = '<p class="test" onclick="alert(1)">Hello World</p>'
     const sanitized = htmlSanitize(html)
     expect(sanitized).toBe('<p class="test">Hello World</p>')
+  })
+})
+
+describe('sanitizeHtml (alias)', () => {
+  it('should be an alias for htmlSanitize', () => {
+    expect(sanitizeHtml).toBe(htmlSanitize)
+  })
+
+  it('should sanitize HTML string', () => {
+    const html = '<script>alert("xss")</script><p>Hello World</p>'
+    const sanitized = sanitizeHtml(html)
+    expect(sanitized).toBe('<p>Hello World</p>')
   })
 })

--- a/src/libs/security/html-sanitize.ts
+++ b/src/libs/security/html-sanitize.ts
@@ -13,3 +13,13 @@ export const htmlSanitize = (
 ): string => {
   return DOMPurify.sanitize(html, config)
 }
+
+/**
+ * Alias for htmlSanitize.
+ * Sanitizes the given HTML string to prevent XSS attacks.
+ *
+ * @param html - The HTML string to sanitize.
+ * @param config - Optional configuration for DOMPurify.
+ * @returns The sanitized HTML string.
+ */
+export const sanitizeHtml = htmlSanitize

--- a/src/libs/transform/wrap-text-with-spans.test.ts
+++ b/src/libs/transform/wrap-text-with-spans.test.ts
@@ -140,9 +140,54 @@ describe('wrapTextWithSpans', () => {
     div.textContent = '👍🎉'
     wrapTextWithSpans(div)
 
-    // Emoji are handled as characters by for...of
+    // Emoji are handled as grapheme clusters
     expect(div.childNodes.length).toBe(2)
     expect(div.childNodes[0].textContent).toBe('👍')
     expect(div.childNodes[1].textContent).toBe('🎉')
+  })
+
+  it('should handle composite emojis (family emoji)', () => {
+    const div = document.createElement('div')
+    div.textContent = '👨‍👩‍👧‍👦'
+    wrapTextWithSpans(div)
+
+    // Family emoji should be treated as a single grapheme cluster
+    expect(div.childNodes.length).toBe(1)
+    expect(div.childNodes[0].textContent).toBe('👨‍👩‍👧‍👦')
+  })
+
+  it('should handle skin tone emojis', () => {
+    const div = document.createElement('div')
+    div.textContent = '👍🏻👍🏿'
+    wrapTextWithSpans(div)
+
+    // Each skin tone emoji should be treated as a single grapheme cluster
+    expect(div.childNodes.length).toBe(2)
+    expect(div.childNodes[0].textContent).toBe('👍🏻')
+    expect(div.childNodes[1].textContent).toBe('👍🏿')
+  })
+
+  it('should handle flag emojis', () => {
+    const div = document.createElement('div')
+    div.textContent = '🇯🇵🇺🇸'
+    wrapTextWithSpans(div)
+
+    // Each flag should be treated as a single grapheme cluster
+    expect(div.childNodes.length).toBe(2)
+    expect(div.childNodes[0].textContent).toBe('🇯🇵')
+    expect(div.childNodes[1].textContent).toBe('🇺🇸')
+  })
+
+  it('should handle mixed text and composite emojis', () => {
+    const div = document.createElement('div')
+    div.textContent = 'Hi👨‍👩‍👧‍👦!'
+    wrapTextWithSpans(div)
+
+    // 'H', 'i', family emoji, '!'
+    expect(div.childNodes.length).toBe(4)
+    expect(div.childNodes[0].textContent).toBe('H')
+    expect(div.childNodes[1].textContent).toBe('i')
+    expect(div.childNodes[2].textContent).toBe('👨‍👩‍👧‍👦')
+    expect(div.childNodes[3].textContent).toBe('!')
   })
 })

--- a/src/libs/transform/wrap-text-with-spans.ts
+++ b/src/libs/transform/wrap-text-with-spans.ts
@@ -1,11 +1,18 @@
+import { runes } from 'runes2'
+
 /**
- * Wraps each character of the text content of an HTML element with individual <span> elements.
+ * Wraps each grapheme cluster (visual character) of the text content of an HTML element with individual <span> elements.
  *
  * @param element - The HTML element whose text content will be wrapped with <span> elements.
  *
  * This function recursively processes the given element and its child nodes. If the node is a text node,
- * it replaces the text content with a series of <span> elements, each containing a single character from the text.
+ * it replaces the text content with a series of <span> elements, each containing a single grapheme cluster from the text.
  * If the node is an element node, it recursively processes its child nodes.
+ *
+ * This function correctly handles:
+ * - Composite emojis (e.g., 👨‍👩‍👧‍👦, 👍🏻)
+ * - Flag emojis (e.g., 🇯🇵)
+ * - Combined characters
  */
 export const wrapTextWithSpans = (element: HTMLElement): void => {
   if (!element) return
@@ -13,9 +20,11 @@ export const wrapTextWithSpans = (element: HTMLElement): void => {
   if (element.nodeType === Node.TEXT_NODE) {
     const textContent = (element.textContent || '').trim()
     const fragment = document.createDocumentFragment()
-    for (const char of textContent) {
+    // Use runes to properly split text into grapheme clusters
+    const graphemes = runes(textContent)
+    for (const grapheme of graphemes) {
       const span = document.createElement('span')
-      span.textContent = char
+      span.textContent = grapheme
       fragment.appendChild(span)
     }
     element.replaceWith(fragment)


### PR DESCRIPTION
## 概要

包括的なライブラリ監査で発見された10件のバグを修正しました。

### 修正内容

| Issue | 修正内容 |
|-------|----------|
| #141 | `sanitizeHtml`エイリアスを追加（README互換性） |
| #142 | `currentConfig`を`_internal.ts`に移動（カプセル化改善） |
| #143 | `getAspectRatio`にゼロ/負数/NaN/Infinity検証を追加 |
| #144 | `getScrollbarWidth`の計算を`documentElement.clientWidth`に修正 |
| #145 | `throttle`/`debounce`に正数検証を追加 |
| #146 | `wrapTextWithSpans`でrunes2を使用し合成絵文字を正しく処理 |
| #147 | `isAfterDateTime`に日付検証を追加（`isBetweenDateTime`との一貫性） |
| #148 | `parseRootMargin`でパーセンテージ計算時に正しい寸法を使用 |
| #149 | `isIpad`と`getOrientation`にSSRガードを追加 |
| #150 | `getUaData`のスペース置換を正規表現に修正（全てのスペースを置換） |

### 変更ファイル数

- 25ファイル変更
- 430行追加、48行削除

## テスト計画

- [x] `pnpm test:run` - 全316テスト通過
- [x] `pnpm lint` - エラーなし
- [x] `pnpm build` - 成功
- [x] コードレビュー実施済み（Critical/Importantなし）

## 破壊的変更の可能性

以下の関数は、以前はsilent failureだったものがエラーをスローするようになります：
- `getAspectRatio(0, 100)` → Error
- `debounce(fn, -100)` → Error
- `throttle(fn, NaN)` → Error
- `isAfterDateTime('invalid')` → Error

これらは本来の意図しない使用方法であり、バグの早期発見に役立ちます。

---

Closes #141, #142, #143, #144, #145, #146, #147, #148, #149, #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)