### PR TITLE
fix: sanitizeHtmlエイリアスを追加（#141）

### DIFF
--- a/src/libs/security/html-sanitize.test.ts
+++ b/src/libs/security/html-sanitize.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { htmlSanitize } from './html-sanitize'
+import { htmlSanitize, sanitizeHtml } from './html-sanitize'
 
 describe('htmlSanitize', () => {
   it('should sanitize HTML string', () => {
@@ -27,5 +27,17 @@ describe('htmlSanitize', () => {
     const html = '<p class="test" onclick="alert(1)">Hello World</p>'
     const sanitized = htmlSanitize(html)
     expect(sanitized).toBe('<p class="test">Hello World</p>')
+  })
+})
+
+describe('sanitizeHtml (alias)', () => {
+  it('should be an alias for htmlSanitize', () => {
+    expect(sanitizeHtml).toBe(htmlSanitize)
+  })
+
+  it('should sanitize HTML string', () => {
+    const html = '<script>alert("xss")</script><p>Hello World</p>'
+    const sanitized = sanitizeHtml(html)
+    expect(sanitized).toBe('<p>Hello World</p>')
   })
 })

--- a/src/libs/security/html-sanitize.ts
+++ b/src/libs/security/html-sanitize.ts
@@ -13,3 +13,13 @@ export const htmlSanitize = (
 ): string => {
   return DOMPurify.sanitize(html, config)
 }
+
+/**
+ * Alias for htmlSanitize.
+ * Sanitizes the given HTML string to prevent XSS attacks.
+ *
+ * @param html - The HTML string to sanitize.
+ * @param config - Optional configuration for DOMPurify.
+ * @returns The sanitized HTML string.
+ */
+export const sanitizeHtml = htmlSanitize


### PR DESCRIPTION
## 概要

READMEに記載されている`sanitizeHtml`関数名との互換性を確保するため、`htmlSanitize`関数のエイリアスとして`sanitizeHtml`をエクスポートしました。

## 変更内容

- `htmlSanitize`のエイリアスとして`sanitizeHtml`を追加
- エイリアスのテストケースを追加

## テスト計画

- [x] `pnpm test:run src/libs/security/html-sanitize.test.ts` - 6テスト通過

---

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)