### PR TITLE
refactor: currentConfigを_internal.tsに移動（#142）

### DIFF
--- a/src/libs/config/_internal.ts
+++ b/src/libs/config/_internal.ts
@@ -1,0 +1,10 @@
+import { defaultConfig } from './default-config'
+import type { UmakiConfig } from './types'
+
+/**
+ * Internal module for shared configuration state.
+ * This module should NOT be exported publicly.
+ */
+
+// The current configuration, starting with the default values
+export const currentConfig: UmakiConfig = { ...defaultConfig }

--- a/src/libs/config/get-config.ts
+++ b/src/libs/config/get-config.ts
@@ -1,8 +1,5 @@
-import { defaultConfig } from './default-config'
+import { currentConfig } from './_internal'
 import type { UmakiConfig } from './types'
-
-// The current configuration, starting with the default values
-const currentConfig: UmakiConfig = { ...defaultConfig }
 
 /**
  * Get the current configuration
@@ -22,6 +19,3 @@ export const getConfigValue = <K extends keyof UmakiConfig>(
 ): UmakiConfig[K] => {
   return currentConfig[key]
 }
-
-// Export for internal use by setConfig
-export { currentConfig }

--- a/src/libs/config/set-config.ts
+++ b/src/libs/config/set-config.ts
@@ -1,4 +1,4 @@
-import { currentConfig } from './get-config'
+import { currentConfig } from './_internal'
 import type { UmakiConfig } from './types'
 
 /**


### PR DESCRIPTION
## 概要

`currentConfig`変数を内部モジュールに移動し、公開APIからの直接アクセスを防止しました。

## 変更内容

- `_internal.ts`を新規作成し、`currentConfig`をここで管理
- `get-config.ts`と`set-config.ts`は`_internal.ts`からインポート
- 公開エクスポートからは除外

## テスト計画

- [x] `pnpm test:run src/libs/config/` - 5テスト通過

---

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)