### PR TITLE
fix: getAspectRatioにゼロ除算・NaN・Infinity検証を追加（#143）

### DIFF
--- a/src/libs/get/get-aspect-ratio.test.ts
+++ b/src/libs/get/get-aspect-ratio.test.ts
@@ -25,4 +25,37 @@ describe('getAspectRatio', () => {
     const result = getAspectRatio(1, 1)
     expect(result).toEqual({ w: 1, h: 1 })
   })
+
+  it('should throw error for zero width', () => {
+    expect(() => getAspectRatio(0, 100)).toThrow(
+      'Width and height must be positive finite numbers'
+    )
+  })
+
+  it('should throw error for zero height', () => {
+    expect(() => getAspectRatio(100, 0)).toThrow(
+      'Width and height must be positive finite numbers'
+    )
+  })
+
+  it('should throw error for negative values', () => {
+    expect(() => getAspectRatio(-16, 9)).toThrow(
+      'Width and height must be positive finite numbers'
+    )
+    expect(() => getAspectRatio(16, -9)).toThrow(
+      'Width and height must be positive finite numbers'
+    )
+  })
+
+  it('should throw error for NaN', () => {
+    expect(() => getAspectRatio(NaN, 100)).toThrow(
+      'Width and height must be positive finite numbers'
+    )
+  })
+
+  it('should throw error for Infinity', () => {
+    expect(() => getAspectRatio(Infinity, 100)).toThrow(
+      'Width and height must be positive finite numbers'
+    )
+  })
 })

--- a/src/libs/get/get-aspect-ratio.ts
+++ b/src/libs/get/get-aspect-ratio.ts
@@ -3,14 +3,18 @@ import { getGcd } from './get-gcd'
 /**
  * Returns the aspect ratio of the given width and height.
  *
- * @param w - The width value.
- * @param h - The height value.
+ * @param w - The width value. Must be a positive number.
+ * @param h - The height value. Must be a positive number.
  * @returns An object containing the width and height of the aspect ratio.
+ * @throws {Error} If width or height is not a positive number.
  */
 export const getAspectRatio = (
   w: number,
   h: number
 ): { w: number; h: number } => {
+  if (w <= 0 || h <= 0 || !Number.isFinite(w) || !Number.isFinite(h)) {
+    throw new Error('Width and height must be positive finite numbers')
+  }
   const gcd = getGcd(w, h)
   return { w: w / gcd, h: h / gcd }
 }


### PR DESCRIPTION
## 概要

`getAspectRatio`関数にエッジケース検証を追加しました。

## 変更内容

- width/heightが0、負数、NaN、Infinityの場合にエラーをスロー
- エッジケースのテストを追加（5件）

## 破壊的変更

以前はゼロ除算時に`Infinity`を返していましたが、エラーをスローするようになりました。

## テスト計画

- [x] `pnpm test:run src/libs/get/get-aspect-ratio.test.ts` - 10テスト通過

---

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)