### PR TITLE
fix: getScrollbarWidthの計算を修正（#144）

### DIFF
--- a/src/libs/get/get-scrollbar-width.test.ts
+++ b/src/libs/get/get-scrollbar-width.test.ts
@@ -1,15 +1,60 @@
 import { getScrollbarWidth } from './get-scrollbar-width'
 
 describe('getScrollbarWidth', () => {
-  it('should return the correct scrollbar width', () => {
-    // Set up the document body with a specific width
-    window.innerWidth = 1024
-    document.body.style.width = '100px'
+  const originalInnerWidth = window.innerWidth
 
-    // Calculate the expected scrollbar width
-    const expectedScrollbarWidth = window.innerWidth - document.body.clientWidth
+  beforeEach(() => {
+    // Reset to original value before each test
+    Object.defineProperty(window, 'innerWidth', {
+      value: 1024,
+      writable: true,
+      configurable: true
+    })
+  })
 
-    // Call the function and check the result
-    expect(getScrollbarWidth()).toBe(expectedScrollbarWidth)
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', {
+      value: originalInnerWidth,
+      writable: true,
+      configurable: true
+    })
+  })
+
+  it('should return the correct scrollbar width using documentElement', () => {
+    Object.defineProperty(window, 'innerWidth', {
+      value: 1024,
+      writable: true,
+      configurable: true
+    })
+
+    // Mock documentElement.clientWidth to simulate scrollbar
+    const originalClientWidth = document.documentElement.clientWidth
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      value: 1009,
+      configurable: true
+    })
+
+    expect(getScrollbarWidth()).toBe(15)
+
+    // Restore
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      value: originalClientWidth,
+      configurable: true
+    })
+  })
+
+  it('should return 0 when no scrollbar is present', () => {
+    Object.defineProperty(window, 'innerWidth', {
+      value: 1024,
+      writable: true,
+      configurable: true
+    })
+
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      value: 1024,
+      configurable: true
+    })
+
+    expect(getScrollbarWidth()).toBe(0)
   })
 })

--- a/src/libs/get/get-scrollbar-width.ts
+++ b/src/libs/get/get-scrollbar-width.ts
@@ -1,7 +1,10 @@
 /**
  * Retrieves the width of the scrollbar.
  *
+ * Uses document.documentElement.clientWidth instead of document.body.clientWidth
+ * to ensure accurate measurement regardless of body element styling (e.g., max-width, margin).
+ *
  * @returns {number} The width of the scrollbar in pixels.
  */
 export const getScrollbarWidth = (): number =>
-  window.innerWidth - document.body.clientWidth
+  window.innerWidth - document.documentElement.clientWidth


### PR DESCRIPTION
## 概要

`getScrollbarWidth`関数の計算方法を修正しました。

## 変更内容

- `body.clientWidth`から`documentElement.clientWidth`に変更
- `body`のスタイルに依存しない、より正確な計算を実現

## テスト計画

- [x] `pnpm test:run src/libs/get/get-scrollbar-width.test.ts` - 2テスト通過

---

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)