### PR TITLE
fix: wrapTextWithSpansで合成絵文字を正しく処理（#146）

### DIFF
--- a/src/libs/transform/wrap-text-with-spans.test.ts
+++ b/src/libs/transform/wrap-text-with-spans.test.ts
@@ -140,9 +140,54 @@ describe('wrapTextWithSpans', () => {
     div.textContent = '👍🎉'
     wrapTextWithSpans(div)
 
-    // Emoji are handled as characters by for...of
+    // Emoji are handled as grapheme clusters
     expect(div.childNodes.length).toBe(2)
     expect(div.childNodes[0].textContent).toBe('👍')
     expect(div.childNodes[1].textContent).toBe('🎉')
+  })
+
+  it('should handle composite emojis (family emoji)', () => {
+    const div = document.createElement('div')
+    div.textContent = '👨‍👩‍👧‍👦'
+    wrapTextWithSpans(div)
+
+    // Family emoji should be treated as a single grapheme cluster
+    expect(div.childNodes.length).toBe(1)
+    expect(div.childNodes[0].textContent).toBe('👨‍👩‍👧‍👦')
+  })
+
+  it('should handle skin tone emojis', () => {
+    const div = document.createElement('div')
+    div.textContent = '👍🏻👍🏿'
+    wrapTextWithSpans(div)
+
+    // Each skin tone emoji should be treated as a single grapheme cluster
+    expect(div.childNodes.length).toBe(2)
+    expect(div.childNodes[0].textContent).toBe('👍🏻')
+    expect(div.childNodes[1].textContent).toBe('👍🏿')
+  })
+
+  it('should handle flag emojis', () => {
+    const div = document.createElement('div')
+    div.textContent = '🇯🇵🇺🇸'
+    wrapTextWithSpans(div)
+
+    // Each flag should be treated as a single grapheme cluster
+    expect(div.childNodes.length).toBe(2)
+    expect(div.childNodes[0].textContent).toBe('🇯🇵')
+    expect(div.childNodes[1].textContent).toBe('🇺🇸')
+  })
+
+  it('should handle mixed text and composite emojis', () => {
+    const div = document.createElement('div')
+    div.textContent = 'Hi👨‍👩‍👧‍👦!'
+    wrapTextWithSpans(div)
+
+    // 'H', 'i', family emoji, '!'
+    expect(div.childNodes.length).toBe(4)
+    expect(div.childNodes[0].textContent).toBe('H')
+    expect(div.childNodes[1].textContent).toBe('i')
+    expect(div.childNodes[2].textContent).toBe('👨‍👩‍👧‍👦')
+    expect(div.childNodes[3].textContent).toBe('!')
   })
 })

--- a/src/libs/transform/wrap-text-with-spans.ts
+++ b/src/libs/transform/wrap-text-with-spans.ts
@@ -1,11 +1,18 @@
+import { runes } from 'runes2'
+
 /**
- * Wraps each character of the text content of an HTML element with individual <span> elements.
+ * Wraps each grapheme cluster (visual character) of the text content of an HTML element with individual <span> elements.
  *
  * @param element - The HTML element whose text content will be wrapped with <span> elements.
  *
  * This function recursively processes the given element and its child nodes. If the node is a text node,
- * it replaces the text content with a series of <span> elements, each containing a single character from the text.
+ * it replaces the text content with a series of <span> elements, each containing a single grapheme cluster from the text.
  * If the node is an element node, it recursively processes its child nodes.
+ *
+ * This function correctly handles:
+ * - Composite emojis (e.g., 👨‍👩‍👧‍👦, 👍🏻)
+ * - Flag emojis (e.g., 🇯🇵)
+ * - Combined characters
  */
 export const wrapTextWithSpans = (element: HTMLElement): void => {
   if (!element) return
@@ -13,9 +20,11 @@ export const wrapTextWithSpans = (element: HTMLElement): void => {
   if (element.nodeType === Node.TEXT_NODE) {
     const textContent = (element.textContent || '').trim()
     const fragment = document.createDocumentFragment()
-    for (const char of textContent) {
+    // Use runes to properly split text into grapheme clusters
+    const graphemes = runes(textContent)
+    for (const grapheme of graphemes) {
       const span = document.createElement('span')
-      span.textContent = char
+      span.textContent = grapheme
       fragment.appendChild(span)
     }
     element.replaceWith(fragment)


### PR DESCRIPTION
## 概要

\`wrapTextWithSpans\`関数で合成絵文字が正しく処理されるよう修正しました。

## 問題

\`for...of\`によるUnicodeコードポイント単位の分割では、ZWJ（ゼロ幅接合子）で結合された合成絵文字が分割されてしまう問題がありました。

例: 家族絵文字 \`👨‍👩‍👧‍👦\` → 7つの\`<span>\`要素に分割

## 解決策

既存の依存関係である\`runes2\`ライブラリを使用し、grapheme cluster単位で分割するよう変更しました。

## 変更内容

- \`for...of\`から\`runes()\`によるgrapheme cluster分割に変更
- 合成絵文字のテストケースを追加（家族絵文字、肌色絵文字、国旗絵文字、混合テキスト）
- JSDocを更新

## テスト計画

- [x] \`pnpm test:run src/libs/transform/wrap-text-with-spans.test.ts\` - 17テスト通過
- [x] コードレビュー実施済み（Ready to Merge）

---

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)