### PR TITLE
fix: isAfterDateTimeに日付検証を追加（#147）

### DIFF
--- a/src/libs/is/is-after-date-time.test.ts
+++ b/src/libs/is/is-after-date-time.test.ts
@@ -52,11 +52,17 @@ describe('isAfterDateTime', () => {
     vi.stubGlobal('dayjs', originalDayjs)
   })
 
-  it('should handle invalid date strings', () => {
+  it('should throw error for invalid date strings', () => {
     const now = dayjs('2023-01-01T12:00:00Z')
 
-    // Invalid dates in dayjs are treated as "Invalid Date"
-    // Check implementation-specific behavior
-    expect(isAfterDateTime('not a date', now)).toBe(false)
+    expect(() => isAfterDateTime('not a date', now)).toThrow(
+      'dateA is not a valid date'
+    )
+  })
+
+  it('should throw error for empty string', () => {
+    const now = dayjs('2023-01-01T12:00:00Z')
+
+    expect(() => isAfterDateTime('', now)).toThrow('dateA is not a valid date')
   })
 })

--- a/src/libs/is/is-after-date-time.ts
+++ b/src/libs/is/is-after-date-time.ts
@@ -7,7 +7,11 @@ import dayjs from 'dayjs'
  * @param dateA - A date/time string to compare, parsed with dayjs.
  * @param now - Optional reference time as a Dayjs object; defaults to current time.
  * @returns `true` if `now` is strictly after the parsed `dateA` at millisecond precision; otherwise `false`.
+ * @throws Will throw an error if dateA is not a valid date.
  */
 export const isAfterDateTime = (dateA: string, now = dayjs()): boolean => {
+  if (!dayjs(dateA).isValid()) {
+    throw new Error('dateA is not a valid date')
+  }
   return now.isAfter(dayjs(dateA), 'millisecond')
 }


### PR DESCRIPTION
## 概要

\`isAfterDateTime\`関数に日付検証を追加し、\`isBetweenDateTime\`との一貫性を確保しました。

## 問題

- \`isAfterDateTime('invalid-date')\` → \`false\`を返す（silent failure）
- \`isBetweenDateTime\` → エラーをスロー

## 解決策

\`isAfterDateTime\`でも無効な日付の場合にエラーをスローするよう修正。

## 破壊的変更

以前は無効な日付で\`false\`を返していましたが、エラーをスローするようになりました。

## テスト計画

- [x] \`pnpm test:run src/libs/is/is-after-date-time.test.ts\` - 8テスト通過

---

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)