### PR TITLE
fix: isIpadとgetOrientationにSSRガードを追加（#149）

### DIFF
--- a/src/libs/get/get-orientation.test.ts
+++ b/src/libs/get/get-orientation.test.ts
@@ -32,4 +32,14 @@ describe('getOrientation', () => {
 
     expect(getOrientation()).toBe('portrait')
   })
+
+  it('should return "portrait" in SSR environment (window undefined)', () => {
+    const originalWindow = global.window
+    // @ts-expect-error - Simulating SSR environment
+    delete global.window
+
+    expect(getOrientation()).toBe('portrait')
+
+    global.window = originalWindow
+  })
 })

--- a/src/libs/get/get-orientation.ts
+++ b/src/libs/get/get-orientation.ts
@@ -2,8 +2,12 @@
  * Retrieves the current orientation of the device.
  *
  * @returns {'landscape' | 'portrait'} The current orientation, either 'landscape' or 'portrait'.
+ * Returns 'portrait' as default in SSR environments where window is undefined.
  */
 export const getOrientation = (): 'landscape' | 'portrait' => {
+  if (typeof window === 'undefined') {
+    return 'portrait'
+  }
   const isLandscape = window.matchMedia('(orientation: landscape)').matches
   return isLandscape ? 'landscape' : 'portrait'
 }

--- a/src/libs/is/is-ipad.test.ts
+++ b/src/libs/is/is-ipad.test.ts
@@ -51,4 +51,24 @@ describe('isIpad', () => {
 
     expect(isIpad('portrait')).toBe(false)
   })
+
+  it('should return false in SSR environment (window undefined)', () => {
+    const originalWindow = global.window
+    // @ts-expect-error - Simulating SSR environment
+    delete global.window
+
+    expect(isIpad()).toBe(false)
+
+    global.window = originalWindow
+  })
+
+  it('should return false in SSR environment (navigator undefined)', () => {
+    const originalNavigator = global.navigator
+    // @ts-expect-error - Simulating SSR environment
+    delete global.navigator
+
+    expect(isIpad()).toBe(false)
+
+    global.navigator = originalNavigator
+  })
 })

--- a/src/libs/is/is-ipad.ts
+++ b/src/libs/is/is-ipad.ts
@@ -8,8 +8,14 @@ type Orientation = 'portrait' | 'landscape'
  *
  * @param orientation - The desired screen orientation ('portrait' or 'landscape'). Defaults to 'portrait'.
  * @returns `true` if the device is an iPad with the specified orientation, otherwise `false`.
+ * Returns `false` in SSR environments where window/navigator is undefined.
  */
 export const isIpad = (orientation: Orientation = 'portrait'): boolean => {
+  // SSR guard: return false if window or navigator is not available
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+    return false
+  }
+
   const clientData = getUaData()
 
   if (!clientData.touchSupport) return false


### PR DESCRIPTION
## 概要

\`isIpad\`と\`getOrientation\`関数にSSR（サーバーサイドレンダリング）ガードを追加しました。

## 問題

SSR環境（Next.js、Nuxtなど）では\`window\`や\`navigator\`が未定義のため、これらの関数を呼び出すとエラーが発生していました。

## 解決策

関数の先頭で環境チェックを追加:
- \`isIpad\`: \`typeof window === 'undefined'\` の場合は\`false\`を返す
- \`getOrientation\`: \`typeof window === 'undefined'\` の場合は\`'portrait'\`を返す

## テスト計画

- [x] \`pnpm test:run src/libs/is/is-ipad.test.ts src/libs/get/get-orientation.test.ts\` - 9テスト通過

---

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)