### PR TITLE
fix: getUaDataのスペース置換を正規表現に修正（#150）

### DIFF
--- a/src/libs/get/get-ua-data.test.ts
+++ b/src/libs/get/get-ua-data.test.ts
@@ -54,4 +54,28 @@ describe('getUaData', () => {
       touchSupport: false
     })
   })
+
+  it('should replace multiple spaces with hyphens', () => {
+    const mockResult = {
+      browser: { name: 'Mobile Safari UI', version: '15.0' },
+      engine: { name: 'WebKit Core' },
+      os: { name: 'Mac OS X' },
+      device: { type: 'mobile device' }
+    }
+    // biome-ignore lint/complexity/useArrowFunction: Vitest requires function/class for constructor mocks
+    ;(UAParser as unknown as Mock).mockImplementation(function () {
+      return { getResult: () => mockResult }
+    })
+
+    const uaData = getUaData()
+
+    expect(uaData).toEqual({
+      browserName: 'mobile-safari-ui',
+      browserVersion: '15.0',
+      browserEngine: 'webkit-core',
+      osName: 'mac-os-x',
+      type: 'mobile-device',
+      touchSupport: false
+    })
+  })
 })

--- a/src/libs/get/get-ua-data.ts
+++ b/src/libs/get/get-ua-data.ts
@@ -36,15 +36,17 @@ export const getUaData = (): UaType => {
   const type = result.device.type
 
   const uaString = {
-    browserName: browserName ? browserName.toLowerCase().replace(' ', '-') : '',
+    browserName: browserName
+      ? browserName.toLowerCase().replace(/ /g, '-')
+      : '',
     browserVersion: browserVersion ? browserVersion : '',
     browserEngine: browserEngine
-      ? browserEngine.toLowerCase().replace(' ', '-')
+      ? browserEngine.toLowerCase().replace(/ /g, '-')
       : '',
-    osName: osName ? osName.toLowerCase().replace(' ', '-') : '',
+    osName: osName ? osName.toLowerCase().replace(/ /g, '-') : '',
     type:
       typeof type !== 'undefined'
-        ? type.toLowerCase().replace(' ', '-')
+        ? type.toLowerCase().replace(/ /g, '-')
         : 'laptop',
     touchSupport: isTouchSupport()
   }


### PR DESCRIPTION
## 概要

\`getUaData\`関数のスペース置換処理を修正しました。

## 問題

\`replace(' ', '-')\`は最初のスペースのみ置換するため、複数のスペースを含む文字列が正しく処理されませんでした。

例: \`'Mobile Safari UI'\` → \`'mobile-safari UI'\`（誤り）

## 解決策

\`replace(/ /g, '-')\`に変更し、全てのスペースを置換。

例: \`'Mobile Safari UI'\` → \`'mobile-safari-ui'\`（正しい）

## テスト計画

- [x] \`pnpm test:run src/libs/get/get-ua-data.test.ts\` - 3テスト通過

---

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)