### PR TITLE
feat: ✨ HEX to RGB変換関数を追加 (#163)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ console.log(breakpoint); // e.g. 768 (default) or custom value if set
   - [videoPlayControl](#videoplaycontrol)
 - [Convert](#convert)
   - [changeDateStringToSpecificFormat](#changedatestringtospecificformat)
+  - [hexToRgb](#hextorgb)
   - [jsonStringToJsonObject](#jsonstringtojsonobject)
 - [EventControl](#eventcontrol)
   - [debounce](#debounce)
@@ -331,6 +332,21 @@ console.log(formattedDateWithDifferentTz); // '2025-04-24 20:00:00'
 Note: This function focuses on timezone handling rather than locale-specific formatting. When a timezone is specified, the date will be converted to that timezone before formatting.
 
 [View file →](src/libs/convert/change-date-string-to-specific-format.ts)
+
+### hexToRgb
+
+A function that converts a hex color string to an RGB color object. Supports `#RGB` / `#RRGGBB` and the same forms without the leading `#`. Returns `undefined` for invalid input.
+
+```ts
+import { hexToRgb } from "umaki";
+
+hexToRgb("#ff0000"); // { r: 255, g: 0, b: 0 }
+hexToRgb("#fff"); // { r: 255, g: 255, b: 255 }
+hexToRgb("abc"); // { r: 170, g: 187, b: 204 }
+hexToRgb("#invalid"); // undefined
+```
+
+[View file →](src/libs/convert/hex-to-rgb.ts)
 
 ### jsonStringToJsonObject
 
@@ -1288,7 +1304,7 @@ import { getUaData, sanitizeHtml } from "umaki";
 | `umaki/callback` | Callback utilities (tap, tapAsync) |
 | `umaki/config` | Configuration (setConfig, getConfig) |
 | `umaki/control` | Scroll control, video playback, etc. |
-| `umaki/convert` | Data conversion (dates, JSON) |
+| `umaki/convert` | Data conversion (dates, JSON, colors) |
 | `umaki/eventControl` | debounce, throttle |
 | `umaki/get` | Value retrieval (DOM, UA, etc.) |
 | `umaki/is` | Boolean checks (device detection, etc.) |

--- a/src/libs/convert/hex-to-rgb.test.ts
+++ b/src/libs/convert/hex-to-rgb.test.ts
@@ -1,0 +1,80 @@
+import { hexToRgb } from './hex-to-rgb'
+
+describe('hexToRgb', () => {
+  describe('valid input', () => {
+    it('converts a 6-digit hex string with leading #', () => {
+      expect(hexToRgb('#ff0000')).toEqual({ r: 255, g: 0, b: 0 })
+      expect(hexToRgb('#00ff00')).toEqual({ r: 0, g: 255, b: 0 })
+      expect(hexToRgb('#0000ff')).toEqual({ r: 0, g: 0, b: 255 })
+    })
+
+    it('converts a 6-digit hex string without leading #', () => {
+      expect(hexToRgb('ff0000')).toEqual({ r: 255, g: 0, b: 0 })
+    })
+
+    it('converts a 3-digit hex string by expanding each digit', () => {
+      expect(hexToRgb('#fff')).toEqual({ r: 255, g: 255, b: 255 })
+      expect(hexToRgb('#000')).toEqual({ r: 0, g: 0, b: 0 })
+      expect(hexToRgb('#abc')).toEqual({ r: 170, g: 187, b: 204 })
+    })
+
+    it('converts a 3-digit hex string without leading #', () => {
+      expect(hexToRgb('fff')).toEqual({ r: 255, g: 255, b: 255 })
+    })
+
+    it('is case-insensitive', () => {
+      expect(hexToRgb('#FFFFFF')).toEqual({ r: 255, g: 255, b: 255 })
+      expect(hexToRgb('#FfAa00')).toEqual({ r: 255, g: 170, b: 0 })
+    })
+
+    it('trims surrounding whitespace', () => {
+      expect(hexToRgb('  #ff0000  ')).toEqual({ r: 255, g: 0, b: 0 })
+    })
+
+    it('handles boundary values', () => {
+      expect(hexToRgb('#000000')).toEqual({ r: 0, g: 0, b: 0 })
+      expect(hexToRgb('#ffffff')).toEqual({ r: 255, g: 255, b: 255 })
+    })
+  })
+
+  describe('invalid input', () => {
+    it('returns undefined for an empty string', () => {
+      expect(hexToRgb('')).toBeUndefined()
+    })
+
+    it('returns undefined for a string containing only #', () => {
+      expect(hexToRgb('#')).toBeUndefined()
+    })
+
+    it('returns undefined for unsupported lengths', () => {
+      expect(hexToRgb('#f')).toBeUndefined()
+      expect(hexToRgb('#ff')).toBeUndefined()
+      expect(hexToRgb('#ffff')).toBeUndefined()
+      expect(hexToRgb('#fffff')).toBeUndefined()
+      expect(hexToRgb('#fffffff')).toBeUndefined()
+      expect(hexToRgb('#ffffffff')).toBeUndefined()
+    })
+
+    it('returns undefined when non-hex characters are present', () => {
+      expect(hexToRgb('#gggggg')).toBeUndefined()
+      expect(hexToRgb('#zz0000')).toBeUndefined()
+      expect(hexToRgb('#ff 000')).toBeUndefined()
+    })
+
+    it('returns undefined for invalid input without leading #', () => {
+      expect(hexToRgb('ggg')).toBeUndefined()
+      expect(hexToRgb('ff')).toBeUndefined()
+      expect(hexToRgb('fffffff')).toBeUndefined()
+    })
+  })
+
+  describe('case-insensitive without leading #', () => {
+    it('handles uppercase 3-digit hex', () => {
+      expect(hexToRgb('ABC')).toEqual({ r: 170, g: 187, b: 204 })
+    })
+
+    it('handles mixed-case 6-digit hex', () => {
+      expect(hexToRgb('FfAa00')).toEqual({ r: 255, g: 170, b: 0 })
+    })
+  })
+})

--- a/src/libs/convert/hex-to-rgb.ts
+++ b/src/libs/convert/hex-to-rgb.ts
@@ -1,0 +1,39 @@
+/**
+ * RGB color components in 0-255 range.
+ */
+export interface RgbColor {
+  r: number
+  g: number
+  b: number
+}
+
+const HEX_PATTERN = /^[0-9a-fA-F]+$/
+
+/**
+ * Converts a hex color string to an RGB color object.
+ * Supports `#RGB`, `#RRGGBB` and the same forms without the leading `#`.
+ *
+ * @param hex - Hex color string (e.g. `#fff`, `#ff0000`, `ff0000`)
+ * @returns RGB color object, or `undefined` if the input is not a valid hex color string.
+ */
+export const hexToRgb = (hex: string): RgbColor | undefined => {
+  const trimmed = hex.trim()
+  const normalized = trimmed.startsWith('#') ? trimmed.slice(1) : trimmed
+
+  if (!HEX_PATTERN.test(normalized)) return undefined
+
+  let expanded: string
+  if (normalized.length === 3) {
+    expanded = `${normalized[0]}${normalized[0]}${normalized[1]}${normalized[1]}${normalized[2]}${normalized[2]}`
+  } else if (normalized.length === 6) {
+    expanded = normalized
+  } else {
+    return undefined
+  }
+
+  return {
+    r: Number.parseInt(expanded.slice(0, 2), 16),
+    g: Number.parseInt(expanded.slice(2, 4), 16),
+    b: Number.parseInt(expanded.slice(4, 6), 16)
+  }
+}

--- a/src/libs/convert/index.ts
+++ b/src/libs/convert/index.ts
@@ -3,4 +3,5 @@
  */
 
 export * from './change-date-string-to-specific-format'
+export * from './hex-to-rgb'
 export * from './json-string-to-json-object'


### PR DESCRIPTION
## 概要

closes #163

`hexToRgb` 関数をconvertカテゴリに追加しました。

### 機能

- `#RGB` / `#RRGGBB` および `#` なしの両形式に対応
- 大文字小文字を区別しない（`FfAa00` → `{ r: 255, g: 170, b: 0 }`）
- 入力前後の空白をトリム
- 不正な hex 文字列は `undefined` を返す
- RGB コンポーネントの型 `RgbColor` をエクスポート

### 使用例

```ts
import { hexToRgb } from 'umaki/convert'

hexToRgb('#ff0000')   // { r: 255, g: 0, b: 0 }
hexToRgb('#fff')      // { r: 255, g: 255, b: 255 }
hexToRgb('abc')       // { r: 170, g: 187, b: 204 }
hexToRgb('#invalid')  // undefined
```

## 変更内容

- `src/libs/convert/hex-to-rgb.ts` を追加
- `src/libs/convert/hex-to-rgb.test.ts` を追加（14ケース、3/6桁・大小文字・空白・境界値・不正入力を網羅）
- `src/libs/convert/index.ts` で re-export

## テスト計画

- [x] `pnpm lint` 通過
- [x] `pnpm test:run` 通過（330 / 330）
- [x] `pnpm build` 通過
- [x] Codex コードレビュー実施済み（Critical/Warning 修正済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)