### PR TITLE
feat: ✨ RGB to HEX変換関数を追加 (#164)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ console.log(breakpoint); // e.g. 768 (default) or custom value if set
 - [Convert](#convert)
   - [changeDateStringToSpecificFormat](#changedatestringtospecificformat)
   - [jsonStringToJsonObject](#jsonstringtojsonobject)
+  - [rgbToHex](#rgbtohex)
 - [EventControl](#eventcontrol)
   - [debounce](#debounce)
   - [throttle](#throttle)
@@ -345,6 +346,22 @@ console.log(jsonObject); // { name: 'John', age: 30 }
 ```
 
 [View file →](src/libs/convert/json-string-to-json-object.ts)
+
+### rgbToHex
+
+A function that converts RGB color components to a 6-digit hex color string with leading `#`. Each component is rounded to the nearest integer and clamped to `[0, 255]`. Non-finite values (`NaN`, `Infinity`, `-Infinity`) are treated as `0`.
+
+```ts
+import { rgbToHex } from "umaki";
+
+rgbToHex(255, 0, 0); // '#ff0000'
+rgbToHex(170, 187, 204); // '#aabbcc'
+rgbToHex(1, 2, 3); // '#010203'
+rgbToHex(300, -10, 128.5); // '#ff0081' (clamped & rounded)
+rgbToHex(NaN, NaN, NaN); // '#000000'
+```
+
+[View file →](src/libs/convert/rgb-to-hex.ts)
 
 ## EventControl
 
@@ -1288,7 +1305,7 @@ import { getUaData, sanitizeHtml } from "umaki";
 | `umaki/callback` | Callback utilities (tap, tapAsync) |
 | `umaki/config` | Configuration (setConfig, getConfig) |
 | `umaki/control` | Scroll control, video playback, etc. |
-| `umaki/convert` | Data conversion (dates, JSON) |
+| `umaki/convert` | Data conversion (dates, JSON, colors) |
 | `umaki/eventControl` | debounce, throttle |
 | `umaki/get` | Value retrieval (DOM, UA, etc.) |
 | `umaki/is` | Boolean checks (device detection, etc.) |

--- a/src/libs/convert/index.ts
+++ b/src/libs/convert/index.ts
@@ -4,3 +4,4 @@
 
 export * from './change-date-string-to-specific-format'
 export * from './json-string-to-json-object'
+export * from './rgb-to-hex'

--- a/src/libs/convert/rgb-to-hex.test.ts
+++ b/src/libs/convert/rgb-to-hex.test.ts
@@ -1,0 +1,58 @@
+import { rgbToHex } from './rgb-to-hex'
+
+describe('rgbToHex', () => {
+  describe('valid input', () => {
+    it('converts primary colors', () => {
+      expect(rgbToHex(255, 0, 0)).toBe('#ff0000')
+      expect(rgbToHex(0, 255, 0)).toBe('#00ff00')
+      expect(rgbToHex(0, 0, 255)).toBe('#0000ff')
+    })
+
+    it('converts black and white boundaries', () => {
+      expect(rgbToHex(0, 0, 0)).toBe('#000000')
+      expect(rgbToHex(255, 255, 255)).toBe('#ffffff')
+    })
+
+    it('zero-pads single-digit hex values', () => {
+      expect(rgbToHex(1, 2, 3)).toBe('#010203')
+      expect(rgbToHex(15, 15, 15)).toBe('#0f0f0f')
+    })
+
+    it('returns lowercase hex digits', () => {
+      expect(rgbToHex(170, 187, 204)).toBe('#aabbcc')
+    })
+
+    it('rounds non-integer values to the nearest integer', () => {
+      expect(rgbToHex(0.4, 0.5, 0.6)).toBe('#000101')
+      expect(rgbToHex(254.5, 254.4, 254.6)).toBe('#fffeff')
+    })
+  })
+
+  describe('out-of-range and non-finite input', () => {
+    it('clamps values above 255 to 255', () => {
+      expect(rgbToHex(300, 1000, 256)).toBe('#ffffff')
+    })
+
+    it('clamps negative values to 0', () => {
+      expect(rgbToHex(-1, -100, -255)).toBe('#000000')
+    })
+
+    it('treats NaN as 0', () => {
+      expect(rgbToHex(Number.NaN, Number.NaN, Number.NaN)).toBe('#000000')
+    })
+
+    it('treats Infinity and -Infinity as 0', () => {
+      expect(
+        rgbToHex(
+          Number.POSITIVE_INFINITY,
+          Number.NEGATIVE_INFINITY,
+          Number.POSITIVE_INFINITY
+        )
+      ).toBe('#000000')
+    })
+
+    it('handles a mix of valid and invalid components', () => {
+      expect(rgbToHex(255, Number.NaN, 128)).toBe('#ff0080')
+    })
+  })
+})

--- a/src/libs/convert/rgb-to-hex.ts
+++ b/src/libs/convert/rgb-to-hex.ts
@@ -1,0 +1,21 @@
+const sanitizeComponent = (value: number): number => {
+  if (!Number.isFinite(value)) return 0
+  return Math.max(0, Math.min(255, Math.round(value)))
+}
+
+const toHexPair = (value: number): string =>
+  sanitizeComponent(value).toString(16).padStart(2, '0')
+
+/**
+ * Converts RGB color components to a 6-digit hex color string with leading `#`.
+ *
+ * Each component is rounded to the nearest integer and clamped to `[0, 255]`.
+ * Non-finite values (`NaN`, `Infinity`, `-Infinity`) are treated as `0`.
+ *
+ * @param r - Red component (0-255)
+ * @param g - Green component (0-255)
+ * @param b - Blue component (0-255)
+ * @returns Lowercase hex color string (e.g. `#ff0000`)
+ */
+export const rgbToHex = (r: number, g: number, b: number): string =>
+  `#${toHexPair(r)}${toHexPair(g)}${toHexPair(b)}`


### PR DESCRIPTION
## 概要

closes #164

`rgbToHex` 関数をconvertカテゴリに追加しました。

### 機能

- `r`, `g`, `b` を個別の引数として受け取り、`#RRGGBB` 形式の小文字 hex 文字列を返す
- 各成分は四捨五入して `[0, 255]` にクランプ
- `NaN` / `Infinity` / `-Infinity` は `0` として扱う
- 1 桁の hex は `0` でゼロ埋めして 2 桁に揃える

### 使用例

```ts
import { rgbToHex } from 'umaki/convert'

rgbToHex(255, 0, 0)        // '#ff0000'
rgbToHex(170, 187, 204)    // '#aabbcc'
rgbToHex(1, 2, 3)          // '#010203'
rgbToHex(300, -10, 128.5)  // '#ff0081' (clamped & rounded)
rgbToHex(NaN, NaN, NaN)    // '#000000'
```

## 変更内容

- `src/libs/convert/rgb-to-hex.ts` を追加
- `src/libs/convert/rgb-to-hex.test.ts` を追加（10ケース、基本色・ゼロ埋め・小文字・四捨五入・上下限クランプ・非有限値・混在を網羅）
- `src/libs/convert/index.ts` で re-export

## テスト計画

- [x] `pnpm lint` 通過
- [x] `pnpm test:run` 通過（326 / 326）
- [x] `pnpm build` 通過
- [x] Codex コードレビュー実施済み（Critical/Warning 指摘なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)