### PR TITLE
release: 🚀 hexToRgb / rgbToHex 関数を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ console.log(breakpoint); // e.g. 768 (default) or custom value if set
   - [videoPlayControl](#videoplaycontrol)
 - [Convert](#convert)
   - [changeDateStringToSpecificFormat](#changedatestringtospecificformat)
+  - [hexToRgb](#hextorgb)
   - [jsonStringToJsonObject](#jsonstringtojsonobject)
 - [EventControl](#eventcontrol)
   - [debounce](#debounce)
@@ -331,6 +332,21 @@ console.log(formattedDateWithDifferentTz); // '2025-04-24 20:00:00'
 Note: This function focuses on timezone handling rather than locale-specific formatting. When a timezone is specified, the date will be converted to that timezone before formatting.
 
 [View file →](src/libs/convert/change-date-string-to-specific-format.ts)
+
+### hexToRgb
+
+A function that converts a hex color string to an RGB color object. Supports `#RGB` / `#RRGGBB` and the same forms without the leading `#`. Returns `undefined` for invalid input.
+
+```ts
+import { hexToRgb } from "umaki";
+
+hexToRgb("#ff0000"); // { r: 255, g: 0, b: 0 }
+hexToRgb("#fff"); // { r: 255, g: 255, b: 255 }
+hexToRgb("abc"); // { r: 170, g: 187, b: 204 }
+hexToRgb("#invalid"); // undefined
+```
+
+[View file →](src/libs/convert/hex-to-rgb.ts)
 
 ### jsonStringToJsonObject
 
@@ -1288,7 +1304,7 @@ import { getUaData, sanitizeHtml } from "umaki";
 | `umaki/callback` | Callback utilities (tap, tapAsync) |
 | `umaki/config` | Configuration (setConfig, getConfig) |
 | `umaki/control` | Scroll control, video playback, etc. |
-| `umaki/convert` | Data conversion (dates, JSON) |
+| `umaki/convert` | Data conversion (dates, JSON, colors) |
 | `umaki/eventControl` | debounce, throttle |
 | `umaki/get` | Value retrieval (DOM, UA, etc.) |
 | `umaki/is` | Boolean checks (device detection, etc.) |

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ console.log(breakpoint); // e.g. 768 (default) or custom value if set
 - [Convert](#convert)
   - [changeDateStringToSpecificFormat](#changedatestringtospecificformat)
   - [jsonStringToJsonObject](#jsonstringtojsonobject)
+  - [rgbToHex](#rgbtohex)
 - [EventControl](#eventcontrol)
   - [debounce](#debounce)
   - [throttle](#throttle)
@@ -345,6 +346,22 @@ console.log(jsonObject); // { name: 'John', age: 30 }
 ```
 
 [View file →](src/libs/convert/json-string-to-json-object.ts)
+
+### rgbToHex
+
+A function that converts RGB color components to a 6-digit hex color string with leading `#`. Each component is rounded to the nearest integer and clamped to `[0, 255]`. Non-finite values (`NaN`, `Infinity`, `-Infinity`) are treated as `0`.
+
+```ts
+import { rgbToHex } from "umaki";
+
+rgbToHex(255, 0, 0); // '#ff0000'
+rgbToHex(170, 187, 204); // '#aabbcc'
+rgbToHex(1, 2, 3); // '#010203'
+rgbToHex(300, -10, 128.5); // '#ff0081' (clamped & rounded)
+rgbToHex(NaN, NaN, NaN); // '#000000'
+```
+
+[View file →](src/libs/convert/rgb-to-hex.ts)
 
 ## EventControl
 
@@ -1288,7 +1305,7 @@ import { getUaData, sanitizeHtml } from "umaki";
 | `umaki/callback` | Callback utilities (tap, tapAsync) |
 | `umaki/config` | Configuration (setConfig, getConfig) |
 | `umaki/control` | Scroll control, video playback, etc. |
-| `umaki/convert` | Data conversion (dates, JSON) |
+| `umaki/convert` | Data conversion (dates, JSON, colors) |
 | `umaki/eventControl` | debounce, throttle |
 | `umaki/get` | Value retrieval (DOM, UA, etc.) |
 | `umaki/is` | Boolean checks (device detection, etc.) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umaki",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "A utility that is often used in web production.",
   "author": "TsubasaHiga",
   "homepage": "https://github.com/TsubasaHiga/umaki",

--- a/src/libs/convert/hex-to-rgb.test.ts
+++ b/src/libs/convert/hex-to-rgb.test.ts
@@ -1,0 +1,80 @@
+import { hexToRgb } from './hex-to-rgb'
+
+describe('hexToRgb', () => {
+  describe('valid input', () => {
+    it('converts a 6-digit hex string with leading #', () => {
+      expect(hexToRgb('#ff0000')).toEqual({ r: 255, g: 0, b: 0 })
+      expect(hexToRgb('#00ff00')).toEqual({ r: 0, g: 255, b: 0 })
+      expect(hexToRgb('#0000ff')).toEqual({ r: 0, g: 0, b: 255 })
+    })
+
+    it('converts a 6-digit hex string without leading #', () => {
+      expect(hexToRgb('ff0000')).toEqual({ r: 255, g: 0, b: 0 })
+    })
+
+    it('converts a 3-digit hex string by expanding each digit', () => {
+      expect(hexToRgb('#fff')).toEqual({ r: 255, g: 255, b: 255 })
+      expect(hexToRgb('#000')).toEqual({ r: 0, g: 0, b: 0 })
+      expect(hexToRgb('#abc')).toEqual({ r: 170, g: 187, b: 204 })
+    })
+
+    it('converts a 3-digit hex string without leading #', () => {
+      expect(hexToRgb('fff')).toEqual({ r: 255, g: 255, b: 255 })
+    })
+
+    it('is case-insensitive', () => {
+      expect(hexToRgb('#FFFFFF')).toEqual({ r: 255, g: 255, b: 255 })
+      expect(hexToRgb('#FfAa00')).toEqual({ r: 255, g: 170, b: 0 })
+    })
+
+    it('trims surrounding whitespace', () => {
+      expect(hexToRgb('  #ff0000  ')).toEqual({ r: 255, g: 0, b: 0 })
+    })
+
+    it('handles boundary values', () => {
+      expect(hexToRgb('#000000')).toEqual({ r: 0, g: 0, b: 0 })
+      expect(hexToRgb('#ffffff')).toEqual({ r: 255, g: 255, b: 255 })
+    })
+  })
+
+  describe('invalid input', () => {
+    it('returns undefined for an empty string', () => {
+      expect(hexToRgb('')).toBeUndefined()
+    })
+
+    it('returns undefined for a string containing only #', () => {
+      expect(hexToRgb('#')).toBeUndefined()
+    })
+
+    it('returns undefined for unsupported lengths', () => {
+      expect(hexToRgb('#f')).toBeUndefined()
+      expect(hexToRgb('#ff')).toBeUndefined()
+      expect(hexToRgb('#ffff')).toBeUndefined()
+      expect(hexToRgb('#fffff')).toBeUndefined()
+      expect(hexToRgb('#fffffff')).toBeUndefined()
+      expect(hexToRgb('#ffffffff')).toBeUndefined()
+    })
+
+    it('returns undefined when non-hex characters are present', () => {
+      expect(hexToRgb('#gggggg')).toBeUndefined()
+      expect(hexToRgb('#zz0000')).toBeUndefined()
+      expect(hexToRgb('#ff 000')).toBeUndefined()
+    })
+
+    it('returns undefined for invalid input without leading #', () => {
+      expect(hexToRgb('ggg')).toBeUndefined()
+      expect(hexToRgb('ff')).toBeUndefined()
+      expect(hexToRgb('fffffff')).toBeUndefined()
+    })
+  })
+
+  describe('case-insensitive without leading #', () => {
+    it('handles uppercase 3-digit hex', () => {
+      expect(hexToRgb('ABC')).toEqual({ r: 170, g: 187, b: 204 })
+    })
+
+    it('handles mixed-case 6-digit hex', () => {
+      expect(hexToRgb('FfAa00')).toEqual({ r: 255, g: 170, b: 0 })
+    })
+  })
+})

--- a/src/libs/convert/hex-to-rgb.ts
+++ b/src/libs/convert/hex-to-rgb.ts
@@ -1,0 +1,39 @@
+/**
+ * RGB color components in 0-255 range.
+ */
+export interface RgbColor {
+  r: number
+  g: number
+  b: number
+}
+
+const HEX_PATTERN = /^[0-9a-fA-F]+$/
+
+/**
+ * Converts a hex color string to an RGB color object.
+ * Supports `#RGB`, `#RRGGBB` and the same forms without the leading `#`.
+ *
+ * @param hex - Hex color string (e.g. `#fff`, `#ff0000`, `ff0000`)
+ * @returns RGB color object, or `undefined` if the input is not a valid hex color string.
+ */
+export const hexToRgb = (hex: string): RgbColor | undefined => {
+  const trimmed = hex.trim()
+  const normalized = trimmed.startsWith('#') ? trimmed.slice(1) : trimmed
+
+  if (!HEX_PATTERN.test(normalized)) return undefined
+
+  let expanded: string
+  if (normalized.length === 3) {
+    expanded = `${normalized[0]}${normalized[0]}${normalized[1]}${normalized[1]}${normalized[2]}${normalized[2]}`
+  } else if (normalized.length === 6) {
+    expanded = normalized
+  } else {
+    return undefined
+  }
+
+  return {
+    r: Number.parseInt(expanded.slice(0, 2), 16),
+    g: Number.parseInt(expanded.slice(2, 4), 16),
+    b: Number.parseInt(expanded.slice(4, 6), 16)
+  }
+}

--- a/src/libs/convert/index.ts
+++ b/src/libs/convert/index.ts
@@ -4,3 +4,4 @@
 
 export * from './change-date-string-to-specific-format'
 export * from './json-string-to-json-object'
+export * from './rgb-to-hex'

--- a/src/libs/convert/index.ts
+++ b/src/libs/convert/index.ts
@@ -3,4 +3,5 @@
  */
 
 export * from './change-date-string-to-specific-format'
+export * from './hex-to-rgb'
 export * from './json-string-to-json-object'

--- a/src/libs/convert/rgb-to-hex.test.ts
+++ b/src/libs/convert/rgb-to-hex.test.ts
@@ -1,0 +1,58 @@
+import { rgbToHex } from './rgb-to-hex'
+
+describe('rgbToHex', () => {
+  describe('valid input', () => {
+    it('converts primary colors', () => {
+      expect(rgbToHex(255, 0, 0)).toBe('#ff0000')
+      expect(rgbToHex(0, 255, 0)).toBe('#00ff00')
+      expect(rgbToHex(0, 0, 255)).toBe('#0000ff')
+    })
+
+    it('converts black and white boundaries', () => {
+      expect(rgbToHex(0, 0, 0)).toBe('#000000')
+      expect(rgbToHex(255, 255, 255)).toBe('#ffffff')
+    })
+
+    it('zero-pads single-digit hex values', () => {
+      expect(rgbToHex(1, 2, 3)).toBe('#010203')
+      expect(rgbToHex(15, 15, 15)).toBe('#0f0f0f')
+    })
+
+    it('returns lowercase hex digits', () => {
+      expect(rgbToHex(170, 187, 204)).toBe('#aabbcc')
+    })
+
+    it('rounds non-integer values to the nearest integer', () => {
+      expect(rgbToHex(0.4, 0.5, 0.6)).toBe('#000101')
+      expect(rgbToHex(254.5, 254.4, 254.6)).toBe('#fffeff')
+    })
+  })
+
+  describe('out-of-range and non-finite input', () => {
+    it('clamps values above 255 to 255', () => {
+      expect(rgbToHex(300, 1000, 256)).toBe('#ffffff')
+    })
+
+    it('clamps negative values to 0', () => {
+      expect(rgbToHex(-1, -100, -255)).toBe('#000000')
+    })
+
+    it('treats NaN as 0', () => {
+      expect(rgbToHex(Number.NaN, Number.NaN, Number.NaN)).toBe('#000000')
+    })
+
+    it('treats Infinity and -Infinity as 0', () => {
+      expect(
+        rgbToHex(
+          Number.POSITIVE_INFINITY,
+          Number.NEGATIVE_INFINITY,
+          Number.POSITIVE_INFINITY
+        )
+      ).toBe('#000000')
+    })
+
+    it('handles a mix of valid and invalid components', () => {
+      expect(rgbToHex(255, Number.NaN, 128)).toBe('#ff0080')
+    })
+  })
+})

--- a/src/libs/convert/rgb-to-hex.ts
+++ b/src/libs/convert/rgb-to-hex.ts
@@ -1,0 +1,21 @@
+const sanitizeComponent = (value: number): number => {
+  if (!Number.isFinite(value)) return 0
+  return Math.max(0, Math.min(255, Math.round(value)))
+}
+
+const toHexPair = (value: number): string =>
+  sanitizeComponent(value).toString(16).padStart(2, '0')
+
+/**
+ * Converts RGB color components to a 6-digit hex color string with leading `#`.
+ *
+ * Each component is rounded to the nearest integer and clamped to `[0, 255]`.
+ * Non-finite values (`NaN`, `Infinity`, `-Infinity`) are treated as `0`.
+ *
+ * @param r - Red component (0-255)
+ * @param g - Green component (0-255)
+ * @param b - Blue component (0-255)
+ * @returns Lowercase hex color string (e.g. `#ff0000`)
+ */
+export const rgbToHex = (r: number, g: number, b: number): string =>
+  `#${toHexPair(r)}${toHexPair(g)}${toHexPair(b)}`


### PR DESCRIPTION
## 概要

`develop` ブランチに蓄積されたカラー変換ユーティリティを `main` にリリースします。

### 含まれる変更

- **feat: ✨ HEX to RGB変換関数を追加 (#163)** — PR #168
  - `hexToRgb`: hex 文字列を RGB オブジェクトに変換（`#RGB` / `#RRGGBB`、大小文字、空白トリム対応）
  - `RgbColor` 型をエクスポート

- **feat: ✨ RGB to HEX変換関数を追加 (#164)** — PR #169
  - `rgbToHex`: RGB 成分を `#RRGGBB` 形式の hex に変換
  - 値は四捨五入のうえ `[0, 255]` にクランプ、非有限値は `0` 扱い

### ドキュメント

- README に両関数の目次・使用例・サブパス説明を追記済み

## テスト計画

- [x] `pnpm lint` 通過
- [x] `pnpm test:run` 通過
- [x] `pnpm build` 通過
- [x] Codex コードレビュー実施済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)