### PR TITLE
chore: 🔒 pnpm に minimumReleaseAge を設定 (#162)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,10 @@
 ignoredBuiltDependencies:
   - '@biomejs/biome'
   - esbuild
+
+# Reject npm releases newer than this many minutes to mitigate supply-chain
+# attacks. 1440 = 24 hours: long enough for malicious versions to typically be
+# detected and yanked, short enough not to block routine updates.
+# Requires pnpm >= 10.16.0.
+# Docs: https://pnpm.io/settings#minimumreleaseage
+minimumReleaseAge: 1440


### PR DESCRIPTION
## 概要

サプライチェーン攻撃対策として、pnpm の [`minimumReleaseAge`](https://pnpm.io/settings#minimumreleaseage) を `pnpm-workspace.yaml` に設定します。公開後 24 時間以内の npm リリースは **インストール時に拒否** され、悪意あるバージョンが検知・yank される前に取り込んでしまうリスクを下げます。

Closes #162

## 変更点

```yaml
# pnpm-workspace.yaml
minimumReleaseAge: 1440  # 24 時間 = 1440 分
```

採用の根拠と参考リンクは YAML 内のインラインコメントに記載しています。

### 値の選択（1440 分 / 24 時間）

| 値 | 強度 | トレードオフ |
| -- | ---- | ------------ |
| 1440 (24h) | 中 | バランス型。**今回採用** |
| 4320 (3 日) | 強 | yank までの実例の多くをカバーするが更新が遅延しやすい |
| 10080 (1 週間) | 最強 | 保守的すぎて Dependabot 更新等が滞る |

24 時間は npm 上の悪意あるパッケージが検知・yank されるまでの実例を多くカバーしつつ、通常の依存更新を妨げないバランスを意図しています。値はあとから安全に増減可能です。

## 影響範囲

- ✅ **CI**: `pnpm install --frozen-lockfile` は既存ロックのバージョンを使うため、本設定の影響を受けません
- ✅ **ローカル開発**: `pnpm install` / `pnpm add` / `pnpm update` で 24 時間以内のリリースのみ拒否されます
- ⚠️ **Dependabot**: 今後導入する場合は `.github/dependabot.yml` 側でも同等の `cooldown` (例: `default-days: 1`) を設定し、本設定と揃えると、pnpm 側で拒否される PR を抑制できます

## 必要環境

- pnpm v10.16.0 以降（本リポジトリは `packageManager` で `pnpm@10.24.0` を固定済み）

## テスト計画

- [x] `pnpm config get minimumReleaseAge` が `1440` を返す
- [x] `pnpm install --frozen-lockfile` が引き続き成功
- [x] `pnpm lint` / `pnpm format` / `pnpm test:run` (356 tests) / `pnpm build` がすべて成功
- [x] Codex レビューによる Warning（Dependabot 連携メモ）を本文に反映済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)